### PR TITLE
[Test] Rest Docs + Swagger UI를 이용한 문서화 환경 세팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Rest Docs Documentation ###
+/src/main/resources/static/docs/openapi3.yaml

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,10 @@ plugins {
     id 'org.springframework.boot' version '3.5.0'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
+
+    // Rest Docs & Swagger UI
+    id 'com.epages.restdocs-api-spec' version '0.18.2'
+    id 'org.hidetake.swagger.generator' version '2.18.2'
 }
 
 group = 'baegam'
@@ -43,9 +47,19 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     // Test
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.rest-assured:rest-assured:5.5.0'
+
+    // Documentation
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-restassured'
+    testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.18.2'
+    testImplementation 'com.epages:restdocs-api-spec-restassured:0.18.2'
+}
+
+bootJar {
+    dependsOn("openapi3")
 }
 
 tasks.named('test', Test) {
@@ -53,7 +67,28 @@ tasks.named('test', Test) {
     useJUnitPlatform()
 }
 
-tasks.named('asciidoctor') {
-    inputs.dir snippetsDir
-    dependsOn test
+generateSwaggerUI {
+    dependsOn("openapi3")
+
+    delete(fileTree("src/main/resources/static/docs/") {
+        exclude(".gitkeep")
+    })
+    copy {
+        from("build/resources/main/static/docs/")
+        into("src/main/resources/static/docs/")
+    }
+}
+
+openapi3 {
+    servers = [ // 서버 상황에 맞춰 추가 예정
+            {
+                url = "http://localhost:8080"
+                description = "Local Server"
+            }
+    ]
+    title = "백암 순대 API" // 수정 예정
+    description = "백암 순대 API" // 수정 예정
+    version = "0.0.1"
+    format = "yaml"
+    outputDirectory = "build/resources/main/static/docs"
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,9 @@
+springdoc:
+  swagger-ui:
+    path: /docs/swagger
+    url: /docs/openapi3.yaml
+    disable-swagger-default-url: true
+    filter: true
+    persist-authorization: true
+    display-request-duration: true
+    default-model-expand-depth: 10

--- a/src/test/java/baegam/sundae/document/BaseDocumentTest.java
+++ b/src/test/java/baegam/sundae/document/BaseDocumentTest.java
@@ -1,0 +1,55 @@
+package baegam.sundae.document;
+
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.restassured.RestAssuredRestDocumentation;
+import org.springframework.restdocs.restassured.RestAssuredRestDocumentationConfigurer;
+import org.springframework.restdocs.restassured.RestDocumentationFilter;
+
+@ExtendWith({RestDocumentationExtension.class, MockitoExtension.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public abstract class BaseDocumentTest {
+
+    // @MockitoBean 을 이용하여 Service Layer 및 특정 객체 Mocking
+
+    @LocalServerPort
+    private int port;
+
+    private RequestSpecification spec;
+
+
+    @BeforeEach
+    void setEnvironment(RestDocumentationContextProvider restDocumentation) {
+        RestAssured.port = port;
+        RestAssuredRestDocumentationConfigurer webConfigurer =
+                RestAssuredRestDocumentation.documentationConfiguration(restDocumentation);
+        spec = new RequestSpecBuilder()
+                .addFilter(webConfigurer)
+                .build();
+    }
+
+    protected final RestDocsRequest request() {
+        return new RestDocsRequest();
+    }
+
+    protected final RestDocsResponse response() {
+        return new RestDocsResponse();
+    }
+
+    protected final RestDocsFilterBuilder document(String identifierPrefix, int statusCode) {
+        return new RestDocsFilterBuilder(identifierPrefix, Integer.toString(statusCode));
+    }
+
+    protected RequestSpecification given(RestDocumentationFilter documentationFilter) {
+        return RestAssured.given(spec)
+                .filter(documentationFilter);
+    }
+}

--- a/src/test/java/baegam/sundae/document/RestDocsFilterBuilder.java
+++ b/src/test/java/baegam/sundae/document/RestDocsFilterBuilder.java
@@ -1,0 +1,67 @@
+package baegam.sundae.document;
+
+import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
+
+import com.epages.restdocs.apispec.ResourceSnippetParametersBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.http.HttpHeaders;
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+import org.springframework.restdocs.restassured.RestDocumentationFilter;
+import org.springframework.restdocs.snippet.Snippet;
+
+public class RestDocsFilterBuilder {
+
+    private static final String IDENTIFIER_DELIMITER = "/";
+    private static final OperationRequestPreprocessor REQUEST_PREPROCESSOR = Preprocessors.preprocessRequest(
+            Preprocessors.prettyPrint(),
+            Preprocessors.modifyHeaders()
+                    .remove(HttpHeaders.HOST)
+                    .remove(HttpHeaders.CONTENT_LENGTH)
+    );
+    private static final OperationResponsePreprocessor RESPONSE_PREPROCESSOR = Preprocessors.preprocessResponse(
+            Preprocessors.prettyPrint(),
+            Preprocessors.modifyHeaders()
+                    .remove(HttpHeaders.TRANSFER_ENCODING)
+                    .remove(HttpHeaders.DATE)
+                    .remove(HttpHeaders.CONNECTION)
+                    .remove(HttpHeaders.CONTENT_LENGTH)
+    );
+
+    private final String identifier;
+    private final List<Snippet> snippets;
+    private ResourceSnippetParametersBuilder resourceBuilder;
+
+    private RestDocsFilterBuilder(String identifier) {
+        this.identifier = identifier;
+        this.resourceBuilder = new ResourceSnippetParametersBuilder();
+        this.snippets = new ArrayList<>();
+    }
+
+    public RestDocsFilterBuilder(String identifierPrefix, String identifier) {
+        this(identifierPrefix + IDENTIFIER_DELIMITER + identifier);
+    }
+
+    public RestDocsFilterBuilder request(RestDocsRequest request) {
+        resourceBuilder = request.getResourceBuilder();
+        snippets.addAll(request.getSnippets());
+        return this;
+    }
+
+    public RestDocsFilterBuilder response(RestDocsResponse response) {
+        snippets.addAll(response.getSnippets());
+        return this;
+    }
+
+    public RestDocumentationFilter build() {
+        return document(
+                identifier,
+                resourceBuilder,
+                REQUEST_PREPROCESSOR,
+                RESPONSE_PREPROCESSOR,
+                snippets.toArray(Snippet[]::new)
+        );
+    }
+}

--- a/src/test/java/baegam/sundae/document/RestDocsRequest.java
+++ b/src/test/java/baegam/sundae/document/RestDocsRequest.java
@@ -1,0 +1,75 @@
+package baegam.sundae.document;
+
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+
+import com.epages.restdocs.apispec.ResourceSnippetParametersBuilder;
+import java.util.LinkedList;
+import java.util.List;
+import org.springframework.restdocs.cookies.CookieDescriptor;
+import org.springframework.restdocs.headers.HeaderDescriptor;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.request.ParameterDescriptor;
+import org.springframework.restdocs.snippet.Snippet;
+
+public class RestDocsRequest {
+
+    private final ResourceSnippetParametersBuilder resourceBuilder;
+    private final List<Snippet> snippets;
+
+    public RestDocsRequest() {
+        this.resourceBuilder = new ResourceSnippetParametersBuilder();
+        this.snippets = new LinkedList<>();
+    }
+
+    public RestDocsRequest tag(Tag tag) {
+        resourceBuilder.tag(tag.getDisplayName());
+        return this;
+    }
+
+    public RestDocsRequest summary(String summary) {
+        resourceBuilder.summary(summary);
+        return this;
+    }
+
+    public RestDocsRequest description(String description) {
+        resourceBuilder.description(description);
+        return this;
+    }
+
+    public RestDocsRequest pathParameter(ParameterDescriptor... descriptors) {
+        snippets.add(pathParameters(descriptors));
+        return this;
+    }
+
+    public RestDocsRequest queryParameter(ParameterDescriptor... descriptors) {
+        snippets.add(queryParameters(descriptors));
+        return this;
+    }
+
+    public RestDocsRequest requestHeader(HeaderDescriptor... descriptors) {
+        snippets.add(requestHeaders(descriptors));
+        return this;
+    }
+
+    public RestDocsRequest requestCookie(CookieDescriptor... descriptors) {
+        snippets.add(requestCookies(descriptors));
+        return this;
+    }
+
+    public RestDocsRequest requestBodyField(FieldDescriptor... descriptors) {
+        snippets.add(requestFields(descriptors));
+        return this;
+    }
+
+    public ResourceSnippetParametersBuilder getResourceBuilder() {
+        return resourceBuilder;
+    }
+
+    public List<Snippet> getSnippets() {
+        return List.copyOf(snippets);
+    }
+}

--- a/src/test/java/baegam/sundae/document/RestDocsResponse.java
+++ b/src/test/java/baegam/sundae/document/RestDocsResponse.java
@@ -1,0 +1,40 @@
+package baegam.sundae.document;
+
+import static org.springframework.restdocs.cookies.CookieDocumentation.responseCookies;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+
+import java.util.LinkedList;
+import java.util.List;
+import org.springframework.restdocs.cookies.CookieDescriptor;
+import org.springframework.restdocs.headers.HeaderDescriptor;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.snippet.Snippet;
+
+public class RestDocsResponse {
+
+    private final List<Snippet> snippets;
+
+    public RestDocsResponse() {
+        this.snippets = new LinkedList<>();
+    }
+
+    public RestDocsResponse responseHeader(HeaderDescriptor... descriptors) {
+        snippets.add(responseHeaders(descriptors));
+        return this;
+    }
+
+    public RestDocsResponse responseCookie(CookieDescriptor... descriptors) {
+        snippets.add(responseCookies(descriptors));
+        return this;
+    }
+
+    public RestDocsResponse responseBodyField(FieldDescriptor... descriptors) {
+        snippets.add(responseFields(descriptors));
+        return this;
+    }
+
+    public List<Snippet> getSnippets() {
+        return List.copyOf(snippets);
+    }
+}

--- a/src/test/java/baegam/sundae/document/Tag.java
+++ b/src/test/java/baegam/sundae/document/Tag.java
@@ -1,0 +1,17 @@
+package baegam.sundae.document;
+
+public enum Tag {
+
+    MEMBER_API("Member API"), // Example (추후 삭제)
+    ;
+
+    private final String displayName;
+
+    Tag(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}


### PR DESCRIPTION
## 🚀 개요

<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- Rest Docs + Swagger UI 를 이용하기 위한 라이브러리 추가 & build.gradle 설정
- Rest Docs를 쉽게 사용하기 위한 편의 객체 추가

## 📗 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] CI/CD 설정 수정
- [ ] 의존성 버전 변경 / 업데이트

## 🔎 상세 내용
- Rest Docs + Swagger UI 를 이용하기 위한 라이브러리 추가 (`com.epages:restdocs-api-spec`, `springdoc-openapi-starter-webmvc-ui`)
-  build.gradle 설정
  - `openapi3` : Rest Docs 정보를 OpenAPI3 형식의 문서로 만들 때, 추가하고 싶은 설정 값 추가
  - `generateSwaggerUI` : build 폴더에서 만들어진 `openapi3.yaml` 파일을 `src.resource` 폴더로 옮겨 로컬 환경에서 실행시켜도 API 명세서를 볼 수 있게 함
- Swagger UI를 보기 편하기 위해 설정 추가 (`application.yml` 참고)
- Rest Docs를 위한 테스트 환경 세팅 & 테스트의 작성 편의성 및 가독성을 올려줄 편의 객체 구현

## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.
