### PR TITLE
[Ci] develop 배포 워크플로우 테스트 및 main 배포 파이프라인 수정

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -78,13 +78,16 @@ jobs:
     runs-on: ubuntu-latest
     environment: develop
     needs: terraform-apply-dev
-    env:
-      ECR_REPOSITORY: ${{ fromJSON(needs.terraform-apply-dev.outputs.tf_outputs_json).ecr_repository_name.value }}
-      ECS_CLUSTER: ${{ fromJSON(needs.terraform-apply-dev.outputs.tf_outputs_json).ecs_cluster_name.value }}
-      ECS_SERVICE: ${{ fromJSON(needs.terraform-apply-dev.outputs.tf_outputs_json).ecs_service_name.value }}
-      CONTAINER_NAME: ${{ fromJSON(needs.terraform-apply-dev.outputs.tf_outputs_json).container_name.value }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Parse Terraform Outputs and Set Environment Variables
+        run: |
+          TF_OUTPUTS='${{ needs.terraform-apply-dev.outputs.tf_outputs_json }}'
+          echo "ECR_REPOSITORY=$(echo "$TF_OUTPUTS" | jq -r '.ecr_repository_name.value')" >> $GITHUB_ENV
+          echo "ECS_CLUSTER=$(echo "$TF_OUTPUTS" | jq -r '.ecs_cluster_name.value')" >> $GITHUB_ENV
+          echo "ECS_SERVICE=$(echo "$TF_OUTPUTS" | jq -r '.ecs_service_name.value')" >> $GITHUB_ENV
+          echo "CONTAINER_NAME=$(echo "$TF_OUTPUTS" | jq -r '.container_name.value')" >> $GITHUB_ENV
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -179,4 +182,3 @@ jobs:
             -X POST \
             -d "{\"content\": \"❌ (개발 서버) 배포 실패!\n레포: ${GITHUB_REPOSITORY}\n브랜치: ${GITHUB_REF}\n버전: ${SEMANTIC_VERSION}\"}" \
             ${{ secrets.DISCORD_WEBHOOK_URL }}
-

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -173,18 +173,36 @@ jobs:
           cluster: ${{ env.ECS_CLUSTER }}
           wait-for-service-stability: true
 
+      - name: Prepare Notification Info
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
       - name: Discord Notify (Success)
         if: success()
-        run: |
-          curl -H "Content-Type: application/json" \
-            -X POST \
-            -d "{\"content\": \"✅ (개발 서버) 새로운 버전이 배포 되었어요!\n레포: ${GITHUB_REPOSITORY}\n브랜치: ${GITHUB_REF}\n버전: ${SEMANTIC_VERSION}\"}" \
-            ${{ secrets.DISCORD_WEBHOOK }}
+        uses: tsickert/discord-webhook@v7.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          embed-title: "✅ 프로덕션 배포 성공!"
+          embed-color: 65280
+          embed-description: |
+            새로운 버전이 성공적으로 배포되었습니다.
+            
+            **버전**: [v${{ env.SEMANTIC_VERSION }}](${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ env.SEMANTIC_VERSION }})
+            **커밋**: [${{ steps.vars.outputs.sha_short }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
+            **배포자**: ${{ github.actor }}
+          embed-url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Discord Notify (Failure)
         if: failure()
-        run: |
-          curl -H "Content-Type: application/json" \
-            -X POST \
-            -d "{\"content\": \"❌ (개발 서버) 배포 실패!\n레포: ${GITHUB_REPOSITORY}\n브랜치: ${GITHUB_REF}\n버전: ${SEMANTIC_VERSION}\"}" \
-            ${{ secrets.DISCORD_WEBHOOK }}
+        uses: tsickert/discord-webhook@v7.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          embed-title: "❌ 프로덕션 배포 실패!"
+          embed-color: 16711680
+          embed-description: |
+            배포 과정 중 오류가 발생했습니다. 아래 링크에서 로그를 확인하세요.
+            
+            **시도 버전**: ${{ env.SEMANTIC_VERSION }}
+            **커밋**: [${{ steps.vars.outputs.sha_short }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
+            **요청자**: ${{ github.actor }}
+          embed-url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -89,8 +89,8 @@ jobs:
           TF_OUTPUTS='${{ needs.terraform-apply-dev.outputs.tf_outputs_json }}'
           echo "ECR_REPOSITORY=$(echo "$TF_OUTPUTS" | jq -r '.ecr_repository_name.value')" >> $GITHUB_ENV
           echo "ECS_CLUSTER=$(echo "$TF_OUTPUTS" | jq -r '.ecs_cluster_name.value')" >> $GITHUB_ENV
-          echo "ECS_SERVICE=$(echo "$TF_OUTPUTS" | jq -r '.ecs_service_name.value')" >> $GITHUB_ENV
-          echo "CONTAINER_NAME=$(echo "$TF_OUTPUTS" | jq -r '.container_name.value')" >> $GITHUB_ENV
+          echo "ECS_SERVICE=$(echo "$TF_OUTPUTS" | jq -r '.ecs_api_service_name.value')" >> $GITHUB_ENV
+          echo "CONTAINER_NAME=$(echo "$TF_OUTPUTS" | jq -r '.ecs_api_container_name.value')" >> $GITHUB_ENV
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ develop ]
     paths:
+      - 'src/**'
       - 'terraform/common/**'
       - 'terraform/dev/**'
       - '.github/workflows/deploy-dev.yml'
@@ -11,6 +12,8 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
+  issues: write
 
 env:
   AWS_REGION: ap-northeast-2
@@ -22,37 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3
-      - name: Terraform Init (common)
-        run: terraform init
-        working-directory: ./terraform/common
-      - name: Terraform Apply COMMON
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: terraform apply -auto-approve
-        working-directory: ./terraform/common
 
-  terraform-apply-dev:
-    name: Terraform Apply dev
-    runs-on: ubuntu-latest
-    needs: terraform-apply-common
-    steps:
-      - uses: actions/checkout@v4
-      - uses: hashicorp/setup-terraform@v3
-      - name: Terraform Init (dev)
-        run: terraform init
-        working-directory: ./terraform/dev
-      - name: Terraform Apply dev
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: terraform apply -auto-approve
-        working-directory: ./terraform/dev
-
-  check-aws-resources:
-    runs-on: ubuntu-latest
-    needs: terraform-apply-dev
-    steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -60,64 +33,59 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Get AWS Resource Names (dev)
-        id: get-aws-names
-        run: |
-          CLUSTER=$(aws ecs list-clusters --region $AWS_REGION --query "clusterArns[]" --output text | tr '\t' '\n' | grep 'dev' | head -n 1 | awk -F'/' '{print $2}')
-          if [ -z "$CLUSTER" ]; then
-            echo "Error: No ECS cluster name containing 'dev' found." >&2
-            exit 1
-          fi
-          echo "ECS_CLUSTER=$CLUSTER" >> $GITHUB_ENV
+      - name: Terraform Init (common)
+        run: terraform init
+        working-directory: ./terraform/common
 
-          SERVICE=$(aws ecs list-services --cluster $CLUSTER --region $AWS_REGION --query "serviceArns[]" --output text | tr '\t' '\n' | grep 'dev' | head -n 1 | awk -F'/' '{print $2}')
-          if [ -z "$SERVICE" ]; then
-            echo "Error: No ECS service name containing 'dev' found." >&2
-            exit 1
-          fi
-          echo "ECS_SERVICE=$SERVICE" >> $GITHUB_ENV
+      - name: Terraform Apply COMMON
+        run: terraform apply -auto-approve
+        working-directory: ./terraform/common
 
-          TASK_DEF_ARN=$(aws ecs describe-services --cluster $CLUSTER --services $SERVICE --region $AWS_REGION --query "services[0].taskDefinition" --output text)
-          if [ -z "$TASK_DEF_ARN" ]; then
-            echo "Error: No ECS task definition ARN found." >&2
-            exit 1
-          fi
-          TASK_DEF_NAME=$(basename "$TASK_DEF_ARN" | cut -d':' -f1)
-          echo "ECS_TASK_DEFINITION=$TASK_DEF_NAME" >> $GITHUB_ENV
+  terraform-apply-dev:
+    name: Terraform Apply dev
+    runs-on: ubuntu-latest
+    needs: terraform-apply-common
+    outputs:
+      tf_outputs_json: ${{ steps.get-outputs.outputs.data }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
 
-          CONTAINER_NAME=$(aws ecs describe-task-definition --task-definition $TASK_DEF_ARN --region $AWS_REGION --query "taskDefinition.containerDefinitions[].name" --output text | tr '\t' '\n' | grep 'dev' | head -n 1)
-          if [ -z "$CONTAINER_NAME" ]; then
-            CONTAINER_NAME=$(aws ecs describe-task-definition --task-definition $TASK_DEF_ARN --region $AWS_REGION --query "taskDefinition.containerDefinitions[0].name" --output text)
-          fi
-          if [ -z "$CONTAINER_NAME" ]; then
-            echo "Error: No ECS container name found." >&2
-            exit 1
-          fi
-          echo "CONTAINER_NAME=$CONTAINER_NAME" >> $GITHUB_ENV
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
 
-          REPO=$(aws ecr describe-repositories --region $AWS_REGION --query "repositories[].repositoryName" --output text | tr '\t' '\n' | grep 'dev' | head -n 1)
-          if [ -z "$REPO" ]; then
-            REPO=$(aws ecr describe-repositories --region $AWS_REGION --query "repositories[0].repositoryName" --output text)
-          fi
-          if [ -z "$REPO" ]; then
-            echo "Error: No ECR repository found." >&2
-            exit 1
-          fi
-          echo "ECR_REPOSITORY=$REPO" >> $GITHUB_ENV
+      - name: Terraform Init (dev)
+        run: terraform init
+        working-directory: ./terraform/dev
+
+      - name: Terraform Apply dev
+        run: terraform apply -auto-approve
+        working-directory: ./terraform/dev
+
+      - name: Get Terraform Outputs
+        id: get-outputs
+        run: echo "data=$(terraform output -json)" >> $GITHUB_OUTPUT
+        working-directory: ./terraform/dev
 
   deploy-service:
     name: Deploy to Amazon ECS
     runs-on: ubuntu-latest
     environment: develop
-    needs: check-aws-resources
+    needs: terraform-apply-dev
     env:
-      ECR_REPOSITORY: ${{ env.ECR_REPOSITORY }}
-      ECS_CLUSTER: ${{ env.ECS_CLUSTER }}
-      ECS_SERVICE: ${{ env.ECS_SERVICE }}
-      ECS_TASK_DEFINITION: ${{ env.ECS_TASK_DEFINITION }}
-      CONTAINER_NAME: ${{ env.CONTAINER_NAME }}
-
+      ECR_REPOSITORY: ${{ fromJSON(needs.terraform-apply-dev.outputs.tf_outputs_json).ecr_repository_name.value }}
+      ECS_CLUSTER: ${{ fromJSON(needs.terraform-apply-dev.outputs.tf_outputs_json).ecs_cluster_name.value }}
+      ECS_SERVICE: ${{ fromJSON(needs.terraform-apply-dev.outputs.tf_outputs_json).ecs_service_name.value }}
+      CONTAINER_NAME: ${{ fromJSON(needs.terraform-apply-dev.outputs.tf_outputs_json).container_name.value }}
     steps:
+      - uses: actions/checkout@v4
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -130,46 +98,16 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Prepare semantic-release config (release all types)
-        run: |
-          cat <<EOF > release.config.js
-          module.exports = {
-            branches: ['develop'],
-            plugins: [
-              [
-                '@semantic-release/commit-analyzer',
-                {
-                  preset: 'conventionalcommits',
-                  releaseRules: [
-                    { type: 'feat', release: 'minor' },
-                    { type: 'fix', release: 'patch' },
-                    { type: 'perf', release: 'patch' },
-                    { type: 'refactor', release: 'patch' },
-                    { type: 'test', release: 'patch' },
-                    { type: 'chore', release: 'patch' },
-                    { type: 'ci', release: 'patch' },
-                    { type: 'revert', release: 'patch' }
-                  ]
-                }
-              ],
-              [
-                '@semantic-release/release-notes-generator',
-                { preset: 'conventionalcommits' }
-              ]
-            ]
-          };
-          EOF
-
       - name: Semantic Release
         run: |
           OUTPUT=$(npx semantic-release --no-ci)
           echo "$OUTPUT"
           VERSION=$(echo "$OUTPUT" | grep -oP 'Published release \K[0-9.]+')
-          if [ ! -z "$VERSION" ]; then
-            echo "SEMANTIC_VERSION=$VERSION" >> $GITHUB_ENV
-          else
-            echo "Error: SEMANTIC_VERSION not extracted" && exit 1
+          if [ -z "$VERSION" ]; then
+            echo "릴리즈할 새로운 버전이 없습니다. 배포를 건너뜁니다."
+            exit 0
           fi
+          echo "SEMANTIC_VERSION=$VERSION" >> $GITHUB_ENV
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -207,8 +145,8 @@ jobs:
       - name: Get latest ECS task definition
         id: get-latest-task-def
         run: |
-          TASK_DEF=$(aws ecs describe-services --cluster ${ECS_CLUSTER} --services ${ECS_SERVICE} --region ${AWS_REGION} --query "services[0].taskDefinition" --output text)
-          aws ecs describe-task-definition --task-definition $TASK_DEF --region ${AWS_REGION} --query "taskDefinition" --output json > task-definition.json
+          TASK_DEF_ARN=$(aws ecs describe-services --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}" --region "${{ env.AWS_REGION }}" --query "services[0].taskDefinition" --output text)
+          aws ecs describe-task-definition --task-definition "$TASK_DEF_ARN" --region "${{ env.AWS_REGION }}" --query "taskDefinition" --output json > task-definition.json
 
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -179,7 +179,7 @@ jobs:
           curl -H "Content-Type: application/json" \
             -X POST \
             -d "{\"content\": \"✅ (개발 서버) 새로운 버전이 배포 되었어요!\n레포: ${GITHUB_REPOSITORY}\n브랜치: ${GITHUB_REF}\n버전: ${SEMANTIC_VERSION}\"}" \
-            ${{ secrets.DISCORD_WEBHOOK_URL }}
+            ${{ secrets.DISCORD_WEBHOOK }}
 
       - name: Discord Notify (Failure)
         if: failure()
@@ -187,4 +187,4 @@ jobs:
           curl -H "Content-Type: application/json" \
             -X POST \
             -d "{\"content\": \"❌ (개발 서버) 배포 실패!\n레포: ${GITHUB_REPOSITORY}\n브랜치: ${GITHUB_REF}\n버전: ${SEMANTIC_VERSION}\"}" \
-            ${{ secrets.DISCORD_WEBHOOK_URL }}
+            ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -70,7 +70,10 @@ jobs:
 
       - name: Get Terraform Outputs
         id: get-outputs
-        run: echo "data=$(terraform output -json)" >> $GITHUB_OUTPUT
+        run: |
+          echo "data<<EOF" >> $GITHUB_OUTPUT
+          terraform output -json >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
         working-directory: ./terraform/dev
 
   deploy-service:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -15,6 +15,10 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: terraform
+  cancel-in-progress: false
+
 env:
   AWS_REGION: ap-northeast-2
 

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -108,10 +108,11 @@ jobs:
         run: npm install semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator conventional-changelog-conventionalcommits
 
       - name: Semantic Release
+        id: get_version
         run: |
           OUTPUT=$(./node_modules/.bin/semantic-release --no-ci)
           echo "$OUTPUT"
-          VERSION=$(echo "$OUTPUT" | grep -oP 'Published release \K[0-9.]+')
+          VERSION=$(echo "$OUTPUT" | grep -oP 'Published prerelease \K[0-9.a-z-]+')
           if [ -z "$VERSION" ]; then
             echo "릴리즈할 새로운 버전이 없습니다. 배포를 건너뜁니다."
             exit 0
@@ -146,9 +147,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$SEMANTIC_VERSION .
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$SEMANTIC_VERSION $ECR_REGISTRY/$ECR_REPOSITORY:latest
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$SEMANTIC_VERSION
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$SEMANTIC_VERSION" >> $GITHUB_ENV
 
       - name: Get latest ECS task definition
@@ -182,7 +181,7 @@ jobs:
         uses: tsickert/discord-webhook@v7.0.0
         with:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
-          embed-title: "✅ 프로덕션 배포 성공!"
+          embed-title: "✅ 개발 서버 배포 성공!"
           embed-color: 65280
           embed-description: |
             새로운 버전이 성공적으로 배포되었습니다.
@@ -197,7 +196,7 @@ jobs:
         uses: tsickert/discord-webhook@v7.0.0
         with:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
-          embed-title: "❌ 프로덕션 배포 실패!"
+          embed-title: "❌ 개발 서버 배포 실패!"
           embed-color: 16711680
           embed-description: |
             배포 과정 중 오류가 발생했습니다. 아래 링크에서 로그를 확인하세요.

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   issues: write
 

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -112,7 +112,7 @@ jobs:
         run: |
           OUTPUT=$(./node_modules/.bin/semantic-release --no-ci)
           echo "$OUTPUT"
-          VERSION=$(echo "$OUTPUT" | grep -oP 'Published prerelease \K[0-9.a-z-]+')
+                    VERSION=$(echo "$OUTPUT" | grep -oP 'Published (?:pre)?release \K[0-9.a-z-]+')
           if [ -z "$VERSION" ]; then
             echo "릴리즈할 새로운 버전이 없습니다. 배포를 건너뜁니다."
             exit 0

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -104,9 +104,12 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Install Semantic Release dependencies
+        run: npm install semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator conventional-changelog-conventionalcommits
+
       - name: Semantic Release
         run: |
-          OUTPUT=$(npx semantic-release --no-ci)
+          OUTPUT=$(./node_modules/.bin/semantic-release --no-ci)
           echo "$OUTPUT"
           VERSION=$(echo "$OUTPUT" | grep -oP 'Published release \K[0-9.]+')
           if [ -z "$VERSION" ]; then

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -20,6 +20,10 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: terraform
+  cancel-in-progress: false
+
 env:
   AWS_REGION: ap-northeast-2
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -190,18 +190,36 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Prepare Notification Info
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
       - name: Discord Notify (Success)
         if: success()
-        run: |
-          curl -H "Content-Type: application/json" \
-            -X POST \
-            -d "{\"content\": \"✅ (프로덕션 서버) 새로운 버전이 배포 되었어요!\n레포: ${GITHUB_REPOSITORY}\n브랜치: ${GITHUB_REF}\n버전: ${SEMANTIC_VERSION}\"}" \
-            ${{ secrets.DISCORD_WEBHOOK }}
+        uses: tsickert/discord-webhook@v7.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          embed-title: "✅ 프로덕션 서버 배포 성공!"
+          embed-color: 65280
+          embed-description: |
+            새로운 버전이 성공적으로 배포되었습니다.
+            
+            **버전**: [v${{ env.SEMANTIC_VERSION }}](${{ github.server_url }}/${{ github.repository }}/releases/tag/v${{ env.SEMANTIC_VERSION }})
+            **커밋**: [${{ steps.vars.outputs.sha_short }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
+            **배포자**: ${{ github.actor }}
+          embed-url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Discord Notify (Failure)
         if: failure()
-        run: |
-          curl -H "Content-Type: application/json" \
-            -X POST \
-            -d "{\"content\": \"❌ (프로덕션 서버) 배포 실패!\n레포: ${GITHUB_REPOSITORY}\n브랜치: ${GITHUB_REF}\n버전: ${SEMANTIC_VERSION}\"}" \
-            ${{ secrets.DISCORD_WEBHOOK }}
+        uses: tsickert/discord-webhook@v7.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          embed-title: "❌ 프로덕션 서버 배포 실패!"
+          embed-color: 16711680
+          embed-description: |
+            배포 과정 중 오류가 발생했습니다. 아래 링크에서 로그를 확인하세요.
+            
+            **시도 버전**: ${{ env.SEMANTIC_VERSION }}
+            **커밋**: [${{ steps.vars.outputs.sha_short }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
+            **요청자**: ${{ github.actor }}
+          embed-url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,244 +1,207 @@
-#name: Deploy PROD & COMMON Infra, Service
-#
-#on:
-#  push:
-#    branches: [ main ]
-#    paths:
-#      - 'terraform/common/**'
-#      - 'terraform/prod/**'
-#      - '.github/workflows/deploy-prod.yml'
-#  workflow_dispatch:
-#
-#permissions:
-#  contents: read
-#
-#env:
-#  AWS_REGION: ap-northeast-2
-#
-#jobs:
-#  terraform-apply-common:
-#    name: Terraform Apply COMMON
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v4
-#      - uses: hashicorp/setup-terraform@v3
-#      - name: Terraform Init (common)
-#        run: terraform init
-#        working-directory: ./terraform/common
-#      - name: Terraform Apply COMMON
-#        env:
-#          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#        run: terraform apply -auto-approve
-#        working-directory: ./terraform/common
-#
-#  terraform-apply-prod:
-#    name: Terraform Apply prod
-#    runs-on: ubuntu-latest
-#    needs: terraform-apply-common
-#    steps:
-#      - uses: actions/checkout@v4
-#      - uses: hashicorp/setup-terraform@v3
-#      - name: Terraform Init (prod)
-#        run: terraform init
-#        working-directory: ./terraform/prod
-#      - name: Terraform Apply prod
-#        env:
-#          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#        run: terraform apply -auto-approve
-#        working-directory: ./terraform/prod
-#
-#  check-aws-resources:
-#    runs-on: ubuntu-latest
-#    needs: terraform-apply-prod
-#    steps:
-#      - name: Configure AWS credentials
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#          aws-region: ${{ env.AWS_REGION }}
-#
-#      - name: Get AWS Resource Names (prod)
-#        id: get-aws-names
-#        run: |
-#          CLUSTER=$(aws ecs list-clusters --region $AWS_REGION --query "clusterArns[]" --output text | tr '\t' '\n' | grep 'prod' | head -n 1 | awk -F'/' '{print $2}')
-#          if [ -z "$CLUSTER" ]; then
-#            echo "Error: No ECS cluster name containing 'prod' found." >&2
-#            exit 1
-#          fi
-#          echo "ECS_CLUSTER=$CLUSTER" >> $GITHUB_ENV
-#
-#          SERVICE=$(aws ecs list-services --cluster $CLUSTER --region $AWS_REGION --query "serviceArns[]" --output text | tr '\t' '\n' | grep 'prod' | head -n 1 | awk -F'/' '{print $2}')
-#          if [ -z "$SERVICE" ]; then
-#            echo "Error: No ECS service name containing 'prod' found." >&2
-#            exit 1
-#          fi
-#          echo "ECS_SERVICE=$SERVICE" >> $GITHUB_ENV
-#
-#          TASK_DEF_ARN=$(aws ecs describe-services --cluster $CLUSTER --services $SERVICE --region $AWS_REGION --query "services[0].taskDefinition" --output text)
-#          if [ -z "$TASK_DEF_ARN" ]; then
-#            echo "Error: No ECS task definition ARN found." >&2
-#            exit 1
-#          fi
-#          TASK_DEF_NAME=$(basename "$TASK_DEF_ARN" | cut -d':' -f1)
-#          echo "ECS_TASK_DEFINITION=$TASK_DEF_NAME" >> $GITHUB_ENV
-#
-#          CONTAINER_NAME=$(aws ecs describe-task-definition --task-definition $TASK_DEF_ARN --region $AWS_REGION --query "taskDefinition.containerDefinitions[].name" --output text | tr '\t' '\n' | grep 'prod' | head -n 1)
-#          if [ -z "$CONTAINER_NAME" ]; then
-#            CONTAINER_NAME=$(aws ecs describe-task-definition --task-definition $TASK_DEF_ARN --region $AWS_REGION --query "taskDefinition.containerDefinitions[0].name" --output text)
-#          fi
-#          if [ -z "$CONTAINER_NAME" ]; then
-#            echo "Error: No ECS container name found." >&2
-#            exit 1
-#          fi
-#          echo "CONTAINER_NAME=$CONTAINER_NAME" >> $GITHUB_ENV
-#
-#          REPO=$(aws ecr describe-repositories --region $AWS_REGION --query "repositories[].repositoryName" --output text | tr '\t' '\n' | grep 'prod' | head -n 1)
-#          if [ -z "$REPO" ]; then
-#            REPO=$(aws ecr describe-repositories --region $AWS_REGION --query "repositories[0].repositoryName" --output text)
-#          fi
-#          if [ -z "$REPO" ]; then
-#            echo "Error: No ECR repository found." >&2
-#            exit 1
-#          fi
-#          echo "ECR_REPOSITORY=$REPO" >> $GITHUB_ENV
-#
-#  deploy-service:
-#    name: Deploy to Amazon ECS
-#    runs-on: ubuntu-latest
-#    environment: production
-#    needs: check-aws-resources
-#    env:
-#      ECR_REPOSITORY: ${{ env.ECR_REPOSITORY }}
-#      ECS_CLUSTER: ${{ env.ECS_CLUSTER }}
-#      ECS_SERVICE: ${{ env.ECS_SERVICE }}
-#      ECS_TASK_DEFINITION: ${{ env.ECS_TASK_DEFINITION }}
-#      CONTAINER_NAME: ${{ env.CONTAINER_NAME }}
-#
-#    steps:
-#      - name: Configure AWS credentials
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#          aws-region: ${{ env.AWS_REGION }}
-#
-#      - name: Set up Node.js
-#        uses: actions/setup-node@v4
-#        with:
-#          node-version: '22'
-#
-#      - name: Prepare semantic-release config (release all types)
-#        run: |
-#          cat <<EOF > release.config.js
-#          module.exports = {
-#            branches: ['develop'],
-#            plugins: [
-#              [
-#                '@semantic-release/commit-analyzer',
-#                {
-#                  preset: 'conventionalcommits',
-#                  releaseRules: [
-#                    { type: 'feat', release: 'minor' },
-#                    { type: 'fix', release: 'patch' },
-#                    { type: 'perf', release: 'patch' },
-#                    { type: 'refactor', release: 'patch' },
-#                    { type: 'test', release: 'patch' },
-#                    { type: 'chore', release: 'patch' },
-#                    { type: 'ci', release: 'patch' },
-#                    { type: 'revert', release: 'patch' }
-#                  ]
-#                }
-#              ],
-#              [
-#                '@semantic-release/release-notes-generator',
-#                { preset: 'conventionalcommits' }
-#              ]
-#            ]
-#          };
-#          EOF
-#
-#      - name: Semantic Release
-#        run: |
-#          OUTPUT=$(npx semantic-release --no-ci)
-#          echo "$OUTPUT"
-#          VERSION=$(echo "$OUTPUT" | grep -oP 'Published release \K[0-9.]+')
-#          if [ ! -z "$VERSION" ]; then
-#            echo "SEMANTIC_VERSION=$VERSION" >> $GITHUB_ENV
-#          else
-#            echo "Error: SEMANTIC_VERSION not extracted" && exit 1
-#          fi
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#
-#      - name: Set up JDK 21
-#        uses: actions/setup-java@v4
-#        with:
-#          distribution: 'temurin'
-#          java-version: 21
-#          java-package: jdk
-#          architecture: 'x64'
-#          cache: 'gradle'
-#
-#      - name: Build with Gradle
-#        run: |
-#          cd ${{ github.workspace }}
-#          chmod +x gradlew
-#          ./gradlew clean build
-#
-#      - name: Login to Amazon ECR
-#        id: login-ecr
-#        uses: aws-actions/amazon-ecr-login@v2
-#        with:
-#          mask-password: 'true'
-#
-#      - name: Build, tag, and push image to Amazon ECR
-#        env:
-#          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-#        run: |
-#          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$SEMANTIC_VERSION .
-#          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$SEMANTIC_VERSION $ECR_REGISTRY/$ECR_REPOSITORY:latest
-#          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$SEMANTIC_VERSION
-#          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
-#          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$SEMANTIC_VERSION" >> $GITHUB_ENV
-#
-#      - name: Get latest ECS task definition
-#        id: get-latest-task-def
-#        run: |
-#          TASK_DEF=$(aws ecs describe-services --cluster ${ECS_CLUSTER} --services ${ECS_SERVICE} --region ${AWS_REGION} --query "services[0].taskDefinition" --output text)
-#          aws ecs describe-task-definition --task-definition $TASK_DEF --region ${AWS_REGION} --query "taskDefinition" --output json > task-definition.json
-#
-#      - name: Fill in the new image ID in the Amazon ECS task definition
-#        id: task-def
-#        uses: aws-actions/amazon-ecs-render-task-definition@v1
-#        with:
-#          task-definition: task-definition.json
-#          container-name: ${{ env.CONTAINER_NAME }}
-#          image: ${{ env.image }}
-#
-#      - name: Deploy Amazon ECS task definition
-#        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-#        with:
-#          task-definition: ${{ steps.task-def.outputs.task-definition }}
-#          service: ${{ env.ECS_SERVICE }}
-#          cluster: ${{ env.ECS_CLUSTER }}
-#          wait-for-service-stability: true
-#
-#      - name: Discord Notify (Success)
-#        if: success()
-#        run: |
-#          curl -H "Content-Type: application/json" \
-#            -X POST \
-#            -d "{\"content\": \"✅ (프로덕션 서버) 새로운 버전이 배포 되었어요!\n레포: ${GITHUB_REPOSITORY}\n브랜치: ${GITHUB_REF}\n버전: ${SEMANTIC_VERSION}\"}" \
-#            ${{ secrets.DISCORD_WEBHOOK_URL }}
-#
-#      - name: Discord Notify (Failure)
-#        if: failure()
-#        run: |
-#          curl -H "Content-Type: application/json" \
-#            -X POST \
-#            -d "{\"content\": \"❌ (프로덕션 서버) 배포 실패!\n레포: ${GITHUB_REPOSITORY}\n브랜치: ${GITHUB_REF}\n버전: ${SEMANTIC_VERSION}\"}" \
-#            ${{ secrets.DISCORD_WEBHOOK_URL }}
-#
+name: Deploy PROD & COMMON Infra, Service
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'terraform/common/**'
+      - 'terraform/prod/**'
+      - '.github/workflows/deploy-prod.yml'
+  workflow_dispatch:
+    inputs:
+      rollback_version:
+        description: '롤백할 버전을 입력하세요 (예: 1.3.0). 비워두면 일반 배포를 실행합니다.'
+        required: false
+        default: ''
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+env:
+  AWS_REGION: ap-northeast-2
+
+jobs:
+  terraform-apply-common:
+    name: Terraform Apply COMMON
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terraform Init (common)
+        run: terraform init
+        working-directory: ./terraform/common
+
+      - name: Terraform Apply COMMON
+        run: terraform apply -auto-approve
+        working-directory: ./terraform/common
+
+  terraform-apply-prod:
+    name: Terraform Apply prod
+    runs-on: ubuntu-latest
+    needs: terraform-apply-common
+    outputs:
+      tf_outputs_json: ${{ steps.get-outputs.outputs.data }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terraform Init (prod)
+        run: terraform init
+        working-directory: ./terraform/prod
+
+      - name: Terraform Apply prod
+        run: terraform apply -auto-approve
+        working-directory: ./terraform/prod
+
+      - name: Get Terraform Outputs
+        id: get-outputs
+        run: |
+          echo "data<<EOF" >> $GITHUB_OUTPUT
+          terraform output -json >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+        working-directory: ./terraform/prod
+
+  deploy-service:
+    name: Deploy to Amazon ECS
+    runs-on: ubuntu-latest
+    environment: production
+    needs: terraform-apply-prod
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse Terraform Outputs and Set Environment Variables
+        run: |
+          TF_OUTPUTS='${{ needs.terraform-apply-prod.outputs.tf_outputs_json }}'
+          echo "ECR_REPOSITORY=$(echo "$TF_OUTPUTS" | jq -r '.ecr_repository_name.value')" >> $GITHUB_ENV
+          echo "ECS_CLUSTER=$(echo "$TF_OUTPUTS" | jq -r '.ecs_cluster_name.value')" >> $GITHUB_ENV
+          echo "ECS_SERVICE=$(echo "$TF_OUTPUTS" | jq -r '.ecs_api_service_name.value')" >> $GITHUB_ENV
+          echo "CONTAINER_NAME=$(echo "$TF_OUTPUTS" | jq -r '.ecs_api_container_name.value')" >> $GITHUB_ENV
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install Semantic Release dependencies
+        run: npm install semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator conventional-changelog-conventionalcommits
+
+      - name: Semantic Release (Dry Run)
+        id: get_version
+        run: |
+          if [[ -n "${{ github.event.inputs.rollback_version }}" ]]; then
+            echo " MANUAL ROLLBACK to version: ${{ github.event.inputs.rollback_version }}"
+            echo "SEMANTIC_VERSION=${{ github.event.inputs.rollback_version }}" >> $GITHUB_ENV
+          else
+            echo "Running semantic-release to determine next version..."
+            OUTPUT=$(./node_modules/.bin/semantic-release --dry-run --no-ci)
+            echo "$OUTPUT"
+            VERSION=$(echo "$OUTPUT" | grep -oP 'The next release version is \K[0-9.a-z-]+')
+            if [ -z "$VERSION" ]; then
+              echo "릴리즈할 새로운 버전이 없습니다. 배포를 건너뜁니다."
+              exit 0
+            fi
+            echo "SEMANTIC_VERSION=$VERSION" >> $GITHUB_ENV
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 21
+          java-package: jdk
+          architecture: 'x64'
+          cache: 'gradle'
+
+      - name: Build with Gradle
+        run: |
+          cd ${{ github.workspace }}
+          chmod +x gradlew
+          ./gradlew clean build
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          mask-password: 'true'
+
+      - name: Build, tag, and push image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$SEMANTIC_VERSION .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$SEMANTIC_VERSION
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$SEMANTIC_VERSION" >> $GITHUB_ENV
+
+      - name: Get latest ECS task definition
+        id: get-latest-task-def
+        run: |
+          TASK_DEF_ARN=$(aws ecs describe-services --cluster "${{ env.ECS_CLUSTER }}" --services "${{ env.ECS_SERVICE }}" --region "${{ env.AWS_REGION }}" --query "services[0].taskDefinition" --output text)
+          aws ecs describe-task-definition --task-definition "$TASK_DEF_ARN" --region "${{ env.AWS_REGION }}" --query "taskDefinition" --output json > task-definition.json
+
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: task-definition.json
+          container-name: ${{ env.CONTAINER_NAME }}
+          image: ${{ env.image }}
+
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          service: ${{ env.ECS_SERVICE }}
+          cluster: ${{ env.ECS_CLUSTER }}
+          wait-for-service-stability: true
+
+      - name: Semantic Release (Final)
+        if: success() && env.SEMANTIC_VERSION != '' && github.event.inputs.rollback_version == ''
+        run: |
+          ./node_modules/.bin/semantic-release --no-ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Discord Notify (Success)
+        if: success()
+        run: |
+          curl -H "Content-Type: application/json" \
+            -X POST \
+            -d "{\"content\": \"✅ (프로덕션 서버) 새로운 버전이 배포 되었어요!\n레포: ${GITHUB_REPOSITORY}\n브랜치: ${GITHUB_REF}\n버전: ${SEMANTIC_VERSION}\"}" \
+            ${{ secrets.DISCORD_WEBHOOK }}
+
+      - name: Discord Notify (Failure)
+        if: failure()
+        run: |
+          curl -H "Content-Type: application/json" \
+            -X POST \
+            -d "{\"content\": \"❌ (프로덕션 서버) 배포 실패!\n레포: ${GITHUB_REPOSITORY}\n브랜치: ${GITHUB_REF}\n버전: ${SEMANTIC_VERSION}\"}" \
+            ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -11,6 +11,10 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: terraform
+  cancel-in-progress: false
+
 jobs:
   plan-common:
     name: "Terraform Plan (common)"

--- a/.releaserc
+++ b/.releaserc
@@ -6,5 +6,29 @@
       "prerelease": true,
       "channel": "beta"
     }
+  ],
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          { "type": "feat", "release": "minor" },
+          { "type": "fix", "release": "patch" },
+          { "type": "perf", "release": "patch" },
+          { "type": "refactor", "release": "patch" },
+          { "type": "test", "release": "patch" },
+          { "type": "chore", "release": "patch" },
+          { "type": "ci", "release": "patch" },
+          { "type": "revert", "release": "patch" }
+        ]
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits"
+      }
+    ]
   ]
 }

--- a/terraform-bootstrap/outputs.tf
+++ b/terraform-bootstrap/outputs.tf
@@ -2,4 +2,10 @@ output "ecr_repo_names" {
   value = {
     for k, v in module.ecr : k => v.repository_url
   }
-} 
+}
+
+output "ecr_repo_name" {
+  value = {
+    for k, v in module.ecr : k => v.repository_name
+  }
+}

--- a/terraform-bootstrap/outputs.tf
+++ b/terraform-bootstrap/outputs.tf
@@ -1,10 +1,10 @@
-output "ecr_repo_names" {
+output "ecr_repo_urls" {
   value = {
     for k, v in module.ecr : k => v.repository_url
   }
 }
 
-output "ecr_repo_name" {
+output "ecr_repo_names" {
   value = {
     for k, v in module.ecr : k => v.repository_name
   }

--- a/terraform/common/alb/locals.tf
+++ b/terraform/common/alb/locals.tf
@@ -3,6 +3,7 @@ locals {
   deletion_protection = false
   loadbalancer_type   = "application"
   internal            = false
+
   alb_tags = {
     Environment = local.alb_name
   }
@@ -11,10 +12,11 @@ locals {
 locals {
   target_groups = {
     "api-dev" = {
-      env         = "dev"
-      port        = 8080
-      protocol    = "HTTP"
-      target_type = "instance"
+      env                  = "dev"
+      port                 = 8080
+      protocol             = "HTTP"
+      target_type          = "instance"
+      deregistration_delay = 60
       health_check = {
         path                = "/actuator/health/"
         protocol            = "HTTP"
@@ -25,10 +27,11 @@ locals {
       }
     }
     "api-prod" = {
-      env         = "prod"
-      port        = 8080
-      protocol    = "HTTP"
-      target_type = "instance"
+      env                  = "prod"
+      port                 = 8080
+      protocol             = "HTTP"
+      target_type          = "instance"
+      deregistration_delay = 60
       health_check = {
         path                = "/actuator/health"
         protocol            = "HTTP"

--- a/terraform/common/alb/target-group/main.tf
+++ b/terraform/common/alb/target-group/main.tf
@@ -1,10 +1,11 @@
 resource "aws_lb_target_group" "common" {
   for_each = var.target_groups
 
-  name        = each.key
-  port        = each.value.port
-  protocol    = each.value.protocol
-  target_type = each.value.target_type
+  name                 = each.key
+  port                 = each.value.port
+  protocol             = each.value.protocol
+  target_type          = each.value.target_type
+  deregistration_delay = each.value.deregistration_delay
 
   vpc_id = var.vpc_id
 

--- a/terraform/common/alb/target-group/variables.tf
+++ b/terraform/common/alb/target-group/variables.tf
@@ -3,6 +3,7 @@ variable "target_groups" {
     port        = number
     protocol    = string
     target_type = string
+    deregistration_delay = number
     health_check = object({
       path                = string
       protocol            = string

--- a/terraform/common/ecr/outputs.tf
+++ b/terraform/common/ecr/outputs.tf
@@ -5,3 +5,7 @@ output "repository_url" {
 output "repository_arn" {
   value = aws_ecr_repository.common.arn
 }
+
+output "repository_name" {
+  value = aws_ecr_repository.common.name
+}

--- a/terraform/dev/ecs/locals.tf
+++ b/terraform/dev/ecs/locals.tf
@@ -1,7 +1,7 @@
 locals {
   cluster_name        = "${var.environment}-cluster"
   launch_type         = "EC2"
-  scheduling_strategy = "REPLICA"
+  scheduling_strategy = "DAEMON"
 
   settings = {
     name  = "containerInsights"
@@ -69,7 +69,6 @@ locals {
   resolved_ecs_services = {
     for name, def in var.ecs_services : name => {
       name          = name
-      desired_count = def.desired_count
       iam_role_arn  = var.ecs_task_definitions[name].task_role_arn
       load_balancer = try(def.load_balancer, null)
     }

--- a/terraform/dev/ecs/locals.tf
+++ b/terraform/dev/ecs/locals.tf
@@ -14,7 +14,7 @@ locals {
     for name, def in var.ecs_task_definitions :
     name => name == "api-dev" ? merge(def, {
       task_definition_name = "api-dev"
-      container_image      = "${var.ecr_repo_names["dev"]}:latest"
+      container_image      = "${var.ecr_repo_urls["dev"]}:latest"
       task_role_arn        = def.task_role_arn
       execution_role_arn   = def.execution_role_arn
       environment = {}

--- a/terraform/dev/ecs/locals.tf
+++ b/terraform/dev/ecs/locals.tf
@@ -14,7 +14,7 @@ locals {
     for name, def in var.ecs_task_definitions :
     name => name == "api-dev" ? merge(def, {
       task_definition_name = "api-dev"
-      container_image      = "${var.ecr_repo_urls["dev"]}:latest"
+      container_image      = "${var.ecr_repo_urls["dev"]}:placeholder"
       task_role_arn        = def.task_role_arn
       execution_role_arn   = def.execution_role_arn
       environment = {}

--- a/terraform/dev/ecs/outputs.tf
+++ b/terraform/dev/ecs/outputs.tf
@@ -1,0 +1,11 @@
+output "cluster_name" {
+  value = module.cluster.cluster_name
+}
+
+output "service_names" {
+  value = module.service.ecs_service_names
+}
+
+output "container_names" {
+  value = module.task.container_names
+}

--- a/terraform/dev/ecs/service/main.tf
+++ b/terraform/dev/ecs/service/main.tf
@@ -5,7 +5,6 @@ resource "aws_ecs_service" "dev" {
   cluster         = var.cluster_id
   launch_type = lookup(each.value, "launch_type", var.launch_type)
   task_definition = var.task_definition_arn[each.key]
-  desired_count   = each.value.desired_count
   scheduling_strategy = lookup(each.value, "scheduling_strategy", var.scheduling_strategy)
 
   dynamic "load_balancer" {

--- a/terraform/dev/ecs/service/outputs.tf
+++ b/terraform/dev/ecs/service/outputs.tf
@@ -1,0 +1,5 @@
+output "ecs_service_names" {
+  value = {
+    for k, v in aws_ecs_service.dev : k => v.name
+  }
+}

--- a/terraform/dev/ecs/service/variables.tf
+++ b/terraform/dev/ecs/service/variables.tf
@@ -1,6 +1,5 @@
 variable "ecs_services" {
   type = map(object({
-    desired_count = number
     load_balancer = object({
       target_group_key = string
       container_name   = string

--- a/terraform/dev/ecs/task/outputs.tf
+++ b/terraform/dev/ecs/task/outputs.tf
@@ -4,3 +4,9 @@ output "task_definition_arns" {
     k => task.arn
   }
 }
+
+output "container_names" {
+  value = {
+    for k, v in aws_ecs_task_definition.dev : k => v.family
+  }
+}

--- a/terraform/dev/ecs/variables.tf
+++ b/terraform/dev/ecs/variables.tf
@@ -2,7 +2,7 @@ variable "environment" {
   type = string
 }
 
-variable "ecr_repo_names" {
+variable "ecr_repo_urls" {
   type = map(string)
 }
 

--- a/terraform/dev/ecs/variables.tf
+++ b/terraform/dev/ecs/variables.tf
@@ -27,7 +27,6 @@ variable "ecs_task_definitions" {
 
 variable "ecs_services" {
   type = map(object({
-    desired_count = number
     load_balancer = optional(object({
       target_group_key = string
       container_name   = string

--- a/terraform/dev/locals.tf
+++ b/terraform/dev/locals.tf
@@ -26,7 +26,7 @@ locals {
   ec2_sg_id                 = data.terraform_remote_state.common.outputs.security_group_ids["ec2"]
   instance_definitions      = data.terraform_remote_state.common.outputs.instance_profile_name["ec2-to-ecs"]
   instance_subnet_map       = data.terraform_remote_state.common.outputs.public_subnet_ids
-  ecr_repo_names            = data.terraform_remote_state.bootstrap.outputs.ecr_repo_names
+  ecr_repo_urls            = data.terraform_remote_state.bootstrap.outputs.ecr_repo_urls
   ecs_services              = var.ecs_services
   ecs_task_definitions_base = var.ecs_task_definitions_base
   alb_target_group_arns     = data.terraform_remote_state.common.outputs.target_group_arns
@@ -68,7 +68,7 @@ locals {
         task_role_arn      = data.terraform_remote_state.common.outputs.role_arn["ecsAppTaskRole"]
       },
         k == "api-dev" ? {
-        container_image = "${data.terraform_remote_state.bootstrap.outputs.ecr_repo_names["dev"]}:latest"
+        container_image = "${data.terraform_remote_state.bootstrap.outputs.ecr_repo_urls["dev"]}:latest"
       } : {},
     )
   }

--- a/terraform/dev/locals.tf
+++ b/terraform/dev/locals.tf
@@ -68,7 +68,7 @@ locals {
         task_role_arn      = data.terraform_remote_state.common.outputs.role_arn["ecsAppTaskRole"]
       },
         k == "api-dev" ? {
-        container_image = "${data.terraform_remote_state.bootstrap.outputs.ecr_repo_urls["dev"]}:latest"
+        container_image = "${data.terraform_remote_state.bootstrap.outputs.ecr_repo_urls["dev"]}:placeholder"
       } : {},
     )
   }

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -10,7 +10,7 @@ module "ec2" {
 module "ecs" {
   source                = "./ecs"
   alb_target_group_arns = local.alb_target_group_arns
-  ecr_repo_names        = local.ecr_repo_names
+  ecr_repo_urls        = local.ecr_repo_urls
   ecs_services          = var.ecs_services
   ecs_task_definitions  = local.ecs_task_definitions
   environment           = local.environment

--- a/terraform/dev/outputs.tf
+++ b/terraform/dev/outputs.tf
@@ -2,6 +2,6 @@ output "ecs_task_definitions_check" {
   value = local.ecs_task_definitions
 }
 
-output "ecr_repository_name" {
-  value = data.terraform_remote_state.bootstrap.outputs.ecr_repo_name["dev"]
+output "ecr_repository_names" {
+  value = data.terraform_remote_state.bootstrap.outputs.ecr_repo_names["dev"]
 }

--- a/terraform/dev/outputs.tf
+++ b/terraform/dev/outputs.tf
@@ -3,7 +3,7 @@ output "ecs_task_definitions_check" {
 }
 
 output "ecr_repository_name" {
-  value = data.terraform_remote_state.bootstrap.outputs.ecr_repo_urls["dev"]
+  value = data.terraform_remote_state.bootstrap.outputs.ecr_repo_names["dev"]
 }
 
 output "ecs_cluster_name" {

--- a/terraform/dev/outputs.tf
+++ b/terraform/dev/outputs.tf
@@ -1,3 +1,7 @@
 output "ecs_task_definitions_check" {
   value = local.ecs_task_definitions
 }
+
+output "ecr_repository_name" {
+  value = data.terraform_remote_state.bootstrap.outputs.ecr_repo_name["dev"]
+}

--- a/terraform/dev/outputs.tf
+++ b/terraform/dev/outputs.tf
@@ -2,6 +2,6 @@ output "ecs_task_definitions_check" {
   value = local.ecs_task_definitions
 }
 
-output "ecr_repository_names" {
+output "ecr_repository_name" {
   value = data.terraform_remote_state.bootstrap.outputs.ecr_repo_names["dev"]
 }

--- a/terraform/dev/outputs.tf
+++ b/terraform/dev/outputs.tf
@@ -5,3 +5,15 @@ output "ecs_task_definitions_check" {
 output "ecr_repository_name" {
   value = data.terraform_remote_state.bootstrap.outputs.ecr_repo_names["dev"]
 }
+
+output "ecs_cluster_name" {
+  value = module.ecs.cluster_name
+}
+
+output "ecs_api_service_name" {
+  value = module.ecs.service_names["api-dev"]
+}
+
+output "ecs_api_container_name" {
+  value = module.ecs.container_names["api-dev"]
+}

--- a/terraform/dev/outputs.tf
+++ b/terraform/dev/outputs.tf
@@ -3,7 +3,7 @@ output "ecs_task_definitions_check" {
 }
 
 output "ecr_repository_name" {
-  value = data.terraform_remote_state.bootstrap.outputs.ecr_repo_names["dev"]
+  value = data.terraform_remote_state.bootstrap.outputs.ecr_repo_urls["dev"]
 }
 
 output "ecs_cluster_name" {

--- a/terraform/dev/terraform.tfvars
+++ b/terraform/dev/terraform.tfvars
@@ -1,6 +1,5 @@
 ecs_services = {
   api-dev = {
-    desired_count   = 1
     task_definition = "api-dev"
     load_balancer = {
       target_group_key = "api-dev"
@@ -10,7 +9,6 @@ ecs_services = {
   }
 
   mysql-dev = {
-    desired_count   = 1
     task_definition = "mysql"
   }
 }

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -1,6 +1,5 @@
 variable "ecs_services" {
   type = map(object({
-    desired_count = number
     load_balancer = optional(object({
       target_group_key = string
       container_name   = string

--- a/terraform/prod/ecs/locals.tf
+++ b/terraform/prod/ecs/locals.tf
@@ -14,7 +14,7 @@ locals {
     for name, def in var.ecs_task_definitions :
     name => name == "api-prod" ? merge(def, {
       task_definition_name = "api-prod"
-      container_image      = "${var.ecr_repo_names["prod"]}:latest"
+      container_image      = "${var.ecr_repo_urls["prod"]}:latest"
       task_role_arn        = def.task_role_arn
       execution_role_arn   = def.execution_role_arn
       environment = {}

--- a/terraform/prod/ecs/locals.tf
+++ b/terraform/prod/ecs/locals.tf
@@ -57,7 +57,6 @@ locals {
   resolved_ecs_services = {
     for name, def in var.ecs_services : name => {
       name          = name
-      desired_count = def.desired_count
       iam_role_arn  = var.ecs_task_definitions[name].task_role_arn
       load_balancer = try(def.load_balancer, null)
     }

--- a/terraform/prod/ecs/locals.tf
+++ b/terraform/prod/ecs/locals.tf
@@ -1,7 +1,7 @@
 locals {
   cluster_name        = "${var.environment}-cluster"
   launch_type         = "EC2"
-  scheduling_strategy = "REPLICA"
+  scheduling_strategy = "DAEMON"
 
   settings = {
     name  = "containerInsights"

--- a/terraform/prod/ecs/locals.tf
+++ b/terraform/prod/ecs/locals.tf
@@ -14,7 +14,7 @@ locals {
     for name, def in var.ecs_task_definitions :
     name => name == "api-prod" ? merge(def, {
       task_definition_name = "api-prod"
-      container_image      = "${var.ecr_repo_urls["prod"]}:latest"
+      container_image      = "${var.ecr_repo_urls["prod"]}:placeholder"
       task_role_arn        = def.task_role_arn
       execution_role_arn   = def.execution_role_arn
       environment = {}

--- a/terraform/prod/ecs/outputs.tf
+++ b/terraform/prod/ecs/outputs.tf
@@ -1,0 +1,11 @@
+output "cluster_name" {
+  value = module.cluster.cluster_name
+}
+
+output "service_names" {
+  value = module.service.ecs_service_names
+}
+
+output "container_names" {
+  value = module.task.container_names
+}

--- a/terraform/prod/ecs/service/main.tf
+++ b/terraform/prod/ecs/service/main.tf
@@ -5,7 +5,6 @@ resource "aws_ecs_service" "prod" {
   cluster         = var.cluster_id
   launch_type = lookup(each.value, "launch_type", var.launch_type)
   task_definition = var.task_definition_arn[each.key]
-  desired_count   = each.value.desired_count
   scheduling_strategy = lookup(each.value, "scheduling_strategy", var.scheduling_strategy)
 
   dynamic "load_balancer" {

--- a/terraform/prod/ecs/service/outputs.tf
+++ b/terraform/prod/ecs/service/outputs.tf
@@ -1,0 +1,5 @@
+output "ecs_service_names" {
+  value = {
+    for k, v in aws_ecs_service.prod : k => v.name
+  }
+}

--- a/terraform/prod/ecs/service/variables.tf
+++ b/terraform/prod/ecs/service/variables.tf
@@ -1,6 +1,5 @@
 variable "ecs_services" {
   type = map(object({
-    desired_count = number
     load_balancer = object({
       target_group_key = string
       container_name   = string

--- a/terraform/prod/ecs/task/outputs.tf
+++ b/terraform/prod/ecs/task/outputs.tf
@@ -4,3 +4,9 @@ output "task_definition_arns" {
     k => task.arn
   }
 }
+
+output "container_names" {
+  value = {
+    for k, v in aws_ecs_task_definition.prod : k => v.family
+  }
+}

--- a/terraform/prod/ecs/variables.tf
+++ b/terraform/prod/ecs/variables.tf
@@ -27,7 +27,6 @@ variable "ecs_task_definitions" {
 
 variable "ecs_services" {
   type = map(object({
-    desired_count = number
     load_balancer = object({
       target_group_key = string
       container_name   = string

--- a/terraform/prod/ecs/variables.tf
+++ b/terraform/prod/ecs/variables.tf
@@ -2,7 +2,7 @@ variable "environment" {
   type = string
 }
 
-variable "ecr_repo_names" {
+variable "ecr_repo_urls" {
   type = map(string)
 }
 

--- a/terraform/prod/locals.tf
+++ b/terraform/prod/locals.tf
@@ -26,7 +26,7 @@ locals {
   ec2_sg_id                 = data.terraform_remote_state.common.outputs.security_group_ids["ec2"]
   instance_definitions      = data.terraform_remote_state.common.outputs.instance_profile_name["ec2-to-ecs"]
   instance_subnet_map       = data.terraform_remote_state.common.outputs.public_subnet_ids
-  ecr_repo_names            = data.terraform_remote_state.bootstrap.outputs.ecr_repo_names
+  ecr_repo_urls             = data.terraform_remote_state.bootstrap.outputs.ecr_repo_urls
   ecs_services              = var.ecs_services
   ecs_task_definitions_base = var.ecs_task_definitions_base
   alb_target_group_arns     = data.terraform_remote_state.common.outputs.target_group_arns
@@ -72,7 +72,7 @@ locals {
         task_role_arn      = data.terraform_remote_state.common.outputs.role_arn["ecsAppTaskRole"]
       },
         k == "api-prod" ? {
-        container_image = "${data.terraform_remote_state.bootstrap.outputs.ecr_repo_names["prod"]}:latest"
+        container_image = "${data.terraform_remote_state.bootstrap.outputs.ecr_repo_urls["prod"]}:latest"
       } : {},
     )
   }

--- a/terraform/prod/locals.tf
+++ b/terraform/prod/locals.tf
@@ -72,7 +72,7 @@ locals {
         task_role_arn      = data.terraform_remote_state.common.outputs.role_arn["ecsAppTaskRole"]
       },
         k == "api-prod" ? {
-        container_image = "${data.terraform_remote_state.bootstrap.outputs.ecr_repo_urls["prod"]}:latest"
+        container_image = "${data.terraform_remote_state.bootstrap.outputs.ecr_repo_urls["prod"]}:placeholder"
       } : {},
     )
   }

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -20,7 +20,7 @@ module "ec2" {
 module "ecs" {
   source                = "./ecs"
   alb_target_group_arns = local.alb_target_group_arns
-  ecr_repo_names        = local.ecr_repo_names
+  ecr_repo_urls        = local.ecr_repo_urls
   ecs_services          = var.ecs_services
   ecs_task_definitions  = local.ecs_task_definitions
   environment           = local.environment

--- a/terraform/prod/outputs.tf
+++ b/terraform/prod/outputs.tf
@@ -1,3 +1,3 @@
 output "ecr_repository_name" {
-  value = data.terraform_remote_state.bootstrap.outputs.ecr_repo_name["prod"]
+  value = data.terraform_remote_state.bootstrap.outputs.ecr_repo_names["prod"]
 }

--- a/terraform/prod/outputs.tf
+++ b/terraform/prod/outputs.tf
@@ -1,5 +1,5 @@
 output "ecr_repository_name" {
-  value = data.terraform_remote_state.bootstrap.outputs.ecr_repo_names["prod"]
+  value = data.terraform_remote_state.bootstrap.outputs.ecr_repo_urls["prod"]
 }
 
 output "ecs_cluster_name" {

--- a/terraform/prod/outputs.tf
+++ b/terraform/prod/outputs.tf
@@ -1,0 +1,3 @@
+output "ecr_repository_name" {
+  value = data.terraform_remote_state.bootstrap.outputs.ecr_repo_name["prod"]
+}

--- a/terraform/prod/outputs.tf
+++ b/terraform/prod/outputs.tf
@@ -1,3 +1,15 @@
 output "ecr_repository_name" {
   value = data.terraform_remote_state.bootstrap.outputs.ecr_repo_names["prod"]
 }
+
+output "ecs_cluster_name" {
+  value = module.ecs.cluster_name
+}
+
+output "ecs_api_service_name" {
+  value = module.ecs.service_names["api-prod"]
+}
+
+output "ecs_api_container_name" {
+  value = module.ecs.container_names["api-prod"]
+}

--- a/terraform/prod/outputs.tf
+++ b/terraform/prod/outputs.tf
@@ -1,5 +1,5 @@
 output "ecr_repository_name" {
-  value = data.terraform_remote_state.bootstrap.outputs.ecr_repo_urls["prod"]
+  value = data.terraform_remote_state.bootstrap.outputs.ecr_repo_names["prod"]
 }
 
 output "ecs_cluster_name" {

--- a/terraform/prod/terraform.tfvars
+++ b/terraform/prod/terraform.tfvars
@@ -1,6 +1,5 @@
 ecs_services = {
   api-prod = {
-    desired_count   = 1
     task_definition = "api-prod"
     load_balancer = {
       target_group_key = "api-prod"
@@ -11,7 +10,6 @@ ecs_services = {
 
   datadog = {
     task_definition     = "datadog"
-    desired_count       = 1
     launch_type         = "EC2"
     scheduling_strategy = "REPLICA"
   }

--- a/terraform/prod/variables.tf
+++ b/terraform/prod/variables.tf
@@ -1,6 +1,5 @@
 variable "ecs_services" {
   type = map(object({
-    desired_count   = number
     task_definition = string
     load_balancer = optional(object({
       target_group_key = string


### PR DESCRIPTION
## ✨ 개요
`develop` 브랜치의 배포 워크플로우 테스트를 완료하고, `main` 브랜치에 적용될 프로덕션 배포 파이프라인을 수정했습니다.

### 1. Terraform 아키텍처 수정
*   "Pass-through" 패턴을 적용하여 모듈의 독립성과 캡슐화를 강화했습니다.
### 2. 환경별 워크플로우 최적화
*   **`prod`**:
    *   `Dry-Run/Final` 패턴을 적용하여, 배포가 100% 성공한 경우에만 GitHub 릴리즈를 생성합니다.
    *   `workflow_dispatch`와 `inputs`을 활용, 특정 버전으로의 수동 롤백 기능을 구현했습니다.
*   **`dev`**:
    *   `semantic-release`의 프리릴리즈 기능(`v1.0.0-develop.1`)을 활용하여 개발 버전 관리를 자동화했습니다.
### 3. 배포 안정성 강화
*   **무중단 배포 불가**: 현재 ECS 서비스는 `DAEMON` 전략으로 배포되므로, 배포 시 5~10분의 다운타임이 발생합니다. 무중단 배포로 전환하려면 EC2 인스턴스 사양의 스케일업이 필요합니다. (스왑 메모리 할당으로는 해결 불가)
*   Discord 알림을 임베드 형식으로 개선하여, 배포된 버전, 커밋, 실행자 정보 및 관련 로그 링크를 한눈에 확인할 수 있도록 했습니다.

## 🧾 관련 이슈
JIRA-PRODUCT-20

## 🔍 참고 사항 (선택)
*   **초기 프로덕션 서버 배포 계획**: 이 PR이 `main` 브랜치에 머지되면, 프로덕션 인프라가 자동으로 배포됩니다. 이 초기 배포는 확인 후 수동으로 정리될 예정이며, 이후 정식 버전 릴리즈부터 파이프라인을 정상 운영합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - Terraform 출력값을 활용하여 ECS 클러스터, 서비스, 컨테이너, ECR 리포지토리 정보 등을 외부에서 직접 참조할 수 있도록 다양한 출력값을 추가하였습니다.
  - 배포 및 알림 워크플로우에서 Discord 웹훅을 통한 배포 성공/실패 알림에 버전, 커밋, 배포자, GitHub 링크 등 풍부한 정보를 포함하도록 개선하였습니다.

- **버그 수정**
  - Docker 이미지 태깅 시 더 이상 latest 태그를 푸시하지 않고, 버전 태그만 푸시하도록 변경하였습니다.

- **리팩터**
  - 배포 워크플로우가 Terraform 출력값을 기반으로 환경 구성을 처리하도록 구조를 단순화하였습니다.
  - AWS 자격증명 및 리소스 참조 방식이 명확하게 개선되었습니다.
  - Semantic-release 설정 및 의존성 설치 절차가 간소화되었습니다.

- **스타일**
  - 일부 변수명 및 출력명 변경(ecr_repo_names → ecr_repo_urls 등)으로 명확성을 높였습니다.

- **기타 작업**
  - ECS 서비스의 desired_count 속성이 제거되어 서비스 인스턴스 수 자동 관리가 가능해졌습니다.
  - ALB 타겟 그룹에 deregistration_delay 속성을 추가하여 연결 해제 지연 시간을 명확히 설정하였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->