### PR TITLE
[Feat] 카카오 로그인 API 연결

### DIFF
--- a/src/main/java/timeeat/client/oauth/OauthClient.java
+++ b/src/main/java/timeeat/client/oauth/OauthClient.java
@@ -1,0 +1,27 @@
+package timeeat.client.oauth;
+
+import java.net.URI;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+public class OauthClient {
+
+    private final String clientId;
+    private final String redirectUri;
+
+    public OauthClient(@Value("${oauth.clientId}") String clientId, @Value("${oauth.redirectUri}") String redirectUri) {
+        this.clientId = clientId;
+        this.redirectUri = redirectUri;
+    }
+
+    public URI getOauthLoginUrl() {
+        return UriComponentsBuilder.fromUriString("https://kauth.kakao.com/oauth/authorize")
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", redirectUri)
+                .queryParam("response_type", "code")
+                .build()
+                .toUri();
+    }
+}

--- a/src/main/java/timeeat/client/oauth/OauthClient.java
+++ b/src/main/java/timeeat/client/oauth/OauthClient.java
@@ -2,6 +2,7 @@ package timeeat.client.oauth;
 
 import java.net.URI;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
@@ -17,7 +18,9 @@ public class OauthClient {
     private final OauthProperties properties;
 
     public OauthClient(RestClient.Builder restClientBuilder, OauthProperties oauthProperties) {
-        this.restClient = restClientBuilder.build();
+        this.restClient = restClientBuilder
+                .defaultStatusHandler(HttpStatusCode::is5xxServerError, new OauthServerErrorHandler())
+                .build();
         this.properties = oauthProperties;
     }
 

--- a/src/main/java/timeeat/client/oauth/OauthClient.java
+++ b/src/main/java/timeeat/client/oauth/OauthClient.java
@@ -2,16 +2,22 @@ package timeeat.client.oauth;
 
 import java.net.URI;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
 @EnableConfigurationProperties(OauthProperties.class)
 public class OauthClient {
 
+    private final RestClient restClient;
     private final OauthProperties properties;
 
-    public OauthClient(OauthProperties oauthProperties) {
+    public OauthClient(RestClient.Builder restClientBuilder, OauthProperties oauthProperties) {
+        this.restClient = restClientBuilder.build();
         this.properties = oauthProperties;
     }
 
@@ -22,5 +28,28 @@ public class OauthClient {
                 .queryParam("response_type", "code")
                 .build()
                 .toUri();
+    }
+
+    public OauthToken requestOauthToken(String code) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", properties.getClientId());
+        body.add("redirect_uri", properties.getRedirectUri());
+        body.add("code", code);
+
+        return restClient.post()
+                .uri("https://kauth.kakao.com/oauth/token")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(body)
+                .retrieve()
+                .body(OauthToken.class);
+    }
+
+    public OauthMemberInformation requestMemberInformation(OauthToken token) {
+        return restClient.get()
+                .uri("https://kapi.kakao.com/v2/user/me")
+                .headers(headers -> headers.setBearerAuth(token.accessToken()))
+                .retrieve()
+                .body(OauthMemberInformation.class);
     }
 }

--- a/src/main/java/timeeat/client/oauth/OauthClient.java
+++ b/src/main/java/timeeat/client/oauth/OauthClient.java
@@ -1,25 +1,24 @@
 package timeeat.client.oauth;
 
 import java.net.URI;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
+@EnableConfigurationProperties(OauthProperties.class)
 public class OauthClient {
 
-    private final String clientId;
-    private final String redirectUri;
+    private final OauthProperties properties;
 
-    public OauthClient(@Value("${oauth.clientId}") String clientId, @Value("${oauth.redirectUri}") String redirectUri) {
-        this.clientId = clientId;
-        this.redirectUri = redirectUri;
+    public OauthClient(OauthProperties oauthProperties) {
+        this.properties = oauthProperties;
     }
 
     public URI getOauthLoginUrl() {
         return UriComponentsBuilder.fromUriString("https://kauth.kakao.com/oauth/authorize")
-                .queryParam("client_id", clientId)
-                .queryParam("redirect_uri", redirectUri)
+                .queryParam("client_id", properties.getClientId())
+                .queryParam("redirect_uri", properties.getRedirectUri())
                 .queryParam("response_type", "code")
                 .build()
                 .toUri();

--- a/src/main/java/timeeat/client/oauth/OauthMemberInformation.java
+++ b/src/main/java/timeeat/client/oauth/OauthMemberInformation.java
@@ -3,7 +3,8 @@ package timeeat.client.oauth;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonDeserialize(using = OauthMemberInformationDeserializer.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record OauthMemberInformation(long socialId, String nickname) {
 }
+

--- a/src/main/java/timeeat/client/oauth/OauthMemberInformation.java
+++ b/src/main/java/timeeat/client/oauth/OauthMemberInformation.java
@@ -1,0 +1,9 @@
+package timeeat.client.oauth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonDeserialize(using = OauthMemberInformationDeserializer.class)
+public record OauthMemberInformation(long socialId, String nickname) {
+}

--- a/src/main/java/timeeat/client/oauth/OauthMemberInformationDeserializer.java
+++ b/src/main/java/timeeat/client/oauth/OauthMemberInformationDeserializer.java
@@ -1,0 +1,23 @@
+package timeeat.client.oauth;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+
+public class OauthMemberInformationDeserializer extends JsonDeserializer<OauthMemberInformation> {
+
+    @Override
+    public OauthMemberInformation deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        JsonNode root = p.getCodec().readTree(p);
+
+        long id = root.path("id").asLong();
+        String nickname = root
+                .path("kakao_account")
+                .path("profile")
+                .path("nickname")
+                .asText(null);
+        return new OauthMemberInformation(id, nickname);
+    }
+}

--- a/src/main/java/timeeat/client/oauth/OauthMemberInformationDeserializer.java
+++ b/src/main/java/timeeat/client/oauth/OauthMemberInformationDeserializer.java
@@ -9,8 +9,9 @@ import java.io.IOException;
 public class OauthMemberInformationDeserializer extends JsonDeserializer<OauthMemberInformation> {
 
     @Override
-    public OauthMemberInformation deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        JsonNode root = p.getCodec().readTree(p);
+    public OauthMemberInformation deserialize(JsonParser jsonParser,
+                                              DeserializationContext deserializationContext) throws IOException {
+        JsonNode root = jsonParser.getCodec().readTree(jsonParser);
 
         long id = root.path("id").asLong();
         String nickname = root

--- a/src/main/java/timeeat/client/oauth/OauthProperties.java
+++ b/src/main/java/timeeat/client/oauth/OauthProperties.java
@@ -1,0 +1,14 @@
+package timeeat.client.oauth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@AllArgsConstructor
+@ConfigurationProperties(prefix = "oauth")
+public class OauthProperties {
+
+    private final String clientId;
+    private final String redirectUri;
+}

--- a/src/main/java/timeeat/client/oauth/OauthServerErrorHandler.java
+++ b/src/main/java/timeeat/client/oauth/OauthServerErrorHandler.java
@@ -1,0 +1,17 @@
+package timeeat.client.oauth;
+
+import java.io.IOException;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient.ResponseSpec.ErrorHandler;
+
+@Component
+public class OauthServerErrorHandler implements ErrorHandler {
+
+    @Override
+    public void handle(HttpRequest request, ClientHttpResponse response) throws IOException {
+        // TODO : 500 에러 처리
+        throw new RuntimeException("Oauth server error occurred");
+    }
+}

--- a/src/main/java/timeeat/client/oauth/OauthToken.java
+++ b/src/main/java/timeeat/client/oauth/OauthToken.java
@@ -1,0 +1,8 @@
+package timeeat.client.oauth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record OauthToken(@JsonProperty("access_token") String accessToken) {
+}

--- a/src/main/java/timeeat/controller/member/MemberController.java
+++ b/src/main/java/timeeat/controller/member/MemberController.java
@@ -1,0 +1,25 @@
+package timeeat.controller.member;
+
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import timeeat.service.member.MemberService;
+
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/api/login/auth")
+    public ResponseEntity<Void> redirectOauthLoginPage() {
+        URI oauthLoginUrl = memberService.getOauthLoginUrl();
+
+        return ResponseEntity
+                .status(302)
+                .location(oauthLoginUrl)
+                .build();
+    }
+}

--- a/src/main/java/timeeat/controller/member/MemberController.java
+++ b/src/main/java/timeeat/controller/member/MemberController.java
@@ -15,7 +15,7 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    @GetMapping("/api/login/auth")
+    @GetMapping("/api/member/login/auth")
     public ResponseEntity<Void> redirectOauthLoginPage() {
         URI oauthLoginUrl = memberService.getOauthLoginUrl();
 
@@ -25,7 +25,7 @@ public class MemberController {
                 .build();
     }
 
-    @PostMapping("/api/login")
+    @PostMapping("/api/member/login")
     public ResponseEntity<String> login(@RequestBody MemberLoginRequest request) {
         memberService.login(request);
         return ResponseEntity.ok("Oauth 로그인 성공"); // TODO 회원 생성 후 정보 반환

--- a/src/main/java/timeeat/controller/member/MemberController.java
+++ b/src/main/java/timeeat/controller/member/MemberController.java
@@ -4,6 +4,8 @@ import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import timeeat.service.member.MemberService;
 
@@ -21,5 +23,11 @@ public class MemberController {
                 .status(302)
                 .location(oauthLoginUrl)
                 .build();
+    }
+
+    @PostMapping("/api/login")
+    public ResponseEntity<String> login(@RequestBody MemberLoginRequest request) {
+        memberService.login(request);
+        return ResponseEntity.ok("Oauth 로그인 성공"); // TODO 회원 생성 후 정보 반환
     }
 }

--- a/src/main/java/timeeat/controller/member/MemberController.java
+++ b/src/main/java/timeeat/controller/member/MemberController.java
@@ -2,6 +2,7 @@ package timeeat.controller.member;
 
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,7 +21,7 @@ public class MemberController {
         URI oauthLoginUrl = memberService.getOauthLoginUrl();
 
         return ResponseEntity
-                .status(302)
+                .status(HttpStatus.FOUND)
                 .location(oauthLoginUrl)
                 .build();
     }

--- a/src/main/java/timeeat/controller/member/MemberLoginRequest.java
+++ b/src/main/java/timeeat/controller/member/MemberLoginRequest.java
@@ -1,0 +1,4 @@
+package timeeat.controller.member;
+
+public record MemberLoginRequest(String code) {
+}

--- a/src/main/java/timeeat/service/member/MemberService.java
+++ b/src/main/java/timeeat/service/member/MemberService.java
@@ -2,9 +2,14 @@ package timeeat.service.member;
 
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import timeeat.client.oauth.OauthClient;
+import timeeat.client.oauth.OauthMemberInformation;
+import timeeat.client.oauth.OauthToken;
+import timeeat.controller.member.MemberLoginRequest;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MemberService {
@@ -13,5 +18,11 @@ public class MemberService {
 
     public URI getOauthLoginUrl() {
         return oauthClient.getOauthLoginUrl();
+    }
+
+    public void login(MemberLoginRequest request) {
+        OauthToken oauthToken = oauthClient.requestOauthToken(request.code());
+        OauthMemberInformation oauthMemberInformation = oauthClient.requestMemberInformation(oauthToken);
+        log.info("Oauth 로그인 성공: {}", oauthMemberInformation); // TODO 회원 정보 저장 로직 추가
     }
 }

--- a/src/main/java/timeeat/service/member/MemberService.java
+++ b/src/main/java/timeeat/service/member/MemberService.java
@@ -1,0 +1,17 @@
+package timeeat.service.member;
+
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import timeeat.client.oauth.OauthClient;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final OauthClient oauthClient;
+
+    public URI getOauthLoginUrl() {
+        return oauthClient.getOauthLoginUrl();
+    }
+}

--- a/src/test/java/timeeat/client/oauth/OauthClientTest.java
+++ b/src/test/java/timeeat/client/oauth/OauthClientTest.java
@@ -6,7 +6,6 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 
 import java.net.URI;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,26 +14,18 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.test.web.client.response.MockRestResponseCreators;
-import org.springframework.web.client.RestClient;
 
 @RestClientTest(OauthClient.class)
 class OauthClientTest {
 
+    @Autowired
     private MockRestServiceServer mockServer;
 
     @Autowired
-    private RestClient.Builder restClientBuilder;
+    private OauthClient oauthClient;
 
     @Autowired
     private OauthProperties properties;
-
-    private OauthClient oauthClient;
-
-    @BeforeEach
-    void setUp() {
-        this.mockServer = MockRestServiceServer.bindTo(restClientBuilder).build();
-        this.oauthClient = new OauthClient(restClientBuilder, properties);
-    }
 
     @Nested
     class GetOauthLoginUrl {

--- a/src/test/java/timeeat/client/oauth/OauthClientTest.java
+++ b/src/test/java/timeeat/client/oauth/OauthClientTest.java
@@ -1,0 +1,32 @@
+package timeeat.client.oauth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.net.URI;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class OauthClientTest {
+
+    private final String clientId = "testClientId";
+    private final String redirectUri = "http://localhost:8080/oauth/callback";
+    private final OauthClient oauthClient = new OauthClient(clientId, redirectUri);
+
+    @Nested
+    class GetOauthLoginUrl {
+
+        @Test
+        void Oauth_로그인_URL을_생성할_수_있다() {
+            URI uri = oauthClient.getOauthLoginUrl();
+
+            assertAll(
+                    () -> assertThat(uri.getHost()).isEqualTo("kauth.kakao.com"),
+                    () -> assertThat(uri.getPath()).isEqualTo("/oauth/authorize"),
+                    () -> assertThat(uri.getQuery()).contains("client_id=%s".formatted(clientId)),
+                    () -> assertThat(uri.getQuery()).contains("redirect_uri=%s".formatted(redirectUri)),
+                    () -> assertThat(uri.getQuery()).contains("response_type=code")
+            );
+        }
+    }
+}

--- a/src/test/java/timeeat/client/oauth/OauthClientTest.java
+++ b/src/test/java/timeeat/client/oauth/OauthClientTest.java
@@ -11,7 +11,7 @@ class OauthClientTest {
 
     private final String clientId = "testClientId";
     private final String redirectUri = "http://localhost:8080/oauth/callback";
-    private final OauthClient oauthClient = new OauthClient(clientId, redirectUri);
+    private final OauthClient oauthClient = new OauthClient(new OauthProperties(clientId, redirectUri));
 
     @Nested
     class GetOauthLoginUrl {

--- a/src/test/java/timeeat/client/oauth/OauthClientTest.java
+++ b/src/test/java/timeeat/client/oauth/OauthClientTest.java
@@ -2,16 +2,39 @@ package timeeat.client.oauth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 
 import java.net.URI;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.client.response.MockRestResponseCreators;
+import org.springframework.web.client.RestClient;
 
+@RestClientTest(OauthClient.class)
 class OauthClientTest {
 
-    private final String clientId = "testClientId";
-    private final String redirectUri = "http://localhost:8080/oauth/callback";
-    private final OauthClient oauthClient = new OauthClient(new OauthProperties(clientId, redirectUri));
+    private MockRestServiceServer mockServer;
+
+    @Autowired
+    private RestClient.Builder restClientBuilder;
+
+    @Autowired
+    private OauthProperties properties;
+
+    private OauthClient oauthClient;
+
+    @BeforeEach
+    void setUp() {
+        this.mockServer = MockRestServiceServer.bindTo(restClientBuilder).build();
+        this.oauthClient = new OauthClient(restClientBuilder, properties);
+    }
 
     @Nested
     class GetOauthLoginUrl {
@@ -23,10 +46,67 @@ class OauthClientTest {
             assertAll(
                     () -> assertThat(uri.getHost()).isEqualTo("kauth.kakao.com"),
                     () -> assertThat(uri.getPath()).isEqualTo("/oauth/authorize"),
-                    () -> assertThat(uri.getQuery()).contains("client_id=%s".formatted(clientId)),
-                    () -> assertThat(uri.getQuery()).contains("redirect_uri=%s".formatted(redirectUri)),
+                    () -> assertThat(uri.getQuery()).contains("client_id=%s".formatted(properties.getClientId())),
+                    () -> assertThat(uri.getQuery()).contains("redirect_uri=%s".formatted(properties.getRedirectUri())),
                     () -> assertThat(uri.getQuery()).contains("response_type=code")
             );
         }
+    }
+
+    @Nested
+    class RequestOauthToken {
+
+        @Test
+        void Oauth_토큰을_요청할_수_있다() {
+            setMockServer(HttpMethod.POST, "https://kauth.kakao.com/oauth/token", """
+                    {
+                        "token_type":"bearer",
+                        "access_token":"test-access-token",
+                        "expires_in":43199,
+                        "refresh_token":"test-refresh-token",
+                        "refresh_token_expires_in":5184000,
+                        "scope":"account_email profile"
+                    }""");
+            String code = "test_code";
+
+            OauthToken token = oauthClient.requestOauthToken(code);
+
+            assertThat(token.accessToken()).isEqualTo("test-access-token");
+        }
+    }
+
+    @Nested
+    class RequestMemberInformation {
+
+        @Test
+        void Oauth_회원정보를_요청할_수_있다() {
+            setMockServer(HttpMethod.GET, "https://kapi.kakao.com/v2/user/me", """
+                    {
+                        "id":123456789,
+                        "connected_at": "2022-04-11T01:45:28Z",
+                        "kakao_account": {
+                            "profile_nickname_needs_agreement": false,
+                            "profile_image_needs_agreement": false,
+                            "profile": {
+                                "nickname": "홍길동",
+                                "is_default_nickname": false
+                            }
+                        }
+                    }""");
+            OauthToken token = new OauthToken("test-access-token");
+
+            OauthMemberInformation memberInfo = oauthClient.requestMemberInformation(token);
+
+            assertAll(
+                    () -> assertThat(memberInfo.socialId()).isEqualTo(123456789L),
+                    () -> assertThat(memberInfo.nickname()).isEqualTo("홍길동")
+            );
+        }
+    }
+
+    public void setMockServer(HttpMethod method, String uri, String responseBody) {
+        mockServer.expect(requestTo(uri))
+                .andExpect(method(method))
+                .andRespond(MockRestResponseCreators.withSuccess(responseBody, MediaType.APPLICATION_JSON));
     }
 }

--- a/src/test/java/timeeat/controller/member/MemberControllerTest.java
+++ b/src/test/java/timeeat/controller/member/MemberControllerTest.java
@@ -24,7 +24,7 @@ class MemberControllerTest extends BaseControllerTest {
             String location = given()
                     .redirects().follow(false)
                     .when()
-                    .get("/api/login/auth")
+                    .get("/api/member/login/auth")
                     .then()
                     .statusCode(302)
                     .extract().header(HttpHeaders.LOCATION);

--- a/src/test/java/timeeat/controller/member/MemberControllerTest.java
+++ b/src/test/java/timeeat/controller/member/MemberControllerTest.java
@@ -1,0 +1,39 @@
+package timeeat.controller.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import timeeat.controller.BaseControllerTest;
+
+class MemberControllerTest extends BaseControllerTest {
+
+    @Nested
+    class RedirectOauthLoginPage {
+
+        @Value("${oauth.clientId}")
+        private String clientId;
+
+        @Value("${oauth.redirectUri}")
+        private String redirectUri;
+
+        @Test
+        void Oauth_로그인_페이지로_리다이렉트_할_수_있다() {
+            String location = given()
+                    .redirects().follow(false)
+                    .when()
+                    .get("/api/login/auth")
+                    .then()
+                    .statusCode(302)
+                    .extract().header(HttpHeaders.LOCATION);
+
+            assertThat(location)
+                    .contains("https://kauth.kakao.com/oauth/authorize")
+                    .contains("client_id=%s".formatted(clientId))
+                    .contains("redirect_uri=%s".formatted(redirectUri))
+                    .contains("response_type=code");
+        }
+    }
+}

--- a/src/test/java/timeeat/document/member/MemberDocumentTest.java
+++ b/src/test/java/timeeat/document/member/MemberDocumentTest.java
@@ -1,9 +1,13 @@
 package timeeat.document.member;
 
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 import timeeat.document.BaseDocumentTest;
 import timeeat.document.RestDocsRequest;
+import timeeat.document.RestDocsResponse;
 import timeeat.document.Tag;
 
 public class MemberDocumentTest extends BaseDocumentTest {
@@ -15,16 +19,22 @@ public class MemberDocumentTest extends BaseDocumentTest {
                 .tag(Tag.MEMBER_API)
                 .summary("OAuth 로그인 페이지 리다이렉트");
 
+        RestDocsResponse responseDocument = response()
+                .responseHeader(
+                        headerWithName(HttpHeaders.LOCATION).description("리다이렉트 URI")
+                );
+
         @Test
         void Oauth_로그인_페이지로_리다이렉트_할_수_있다() {
             var document = document("member/oauth_redirect", 302)
                     .request(requestDocument)
+                    .response(responseDocument)
                     .build();
 
             given(document)
                     .redirects().follow(false)
                     .when()
-                    .get("/api/login/auth")
+                    .get("/api/member/login/auth")
                     .then()
                     .statusCode(302);
         }

--- a/src/test/java/timeeat/document/member/MemberDocumentTest.java
+++ b/src/test/java/timeeat/document/member/MemberDocumentTest.java
@@ -3,15 +3,23 @@ package timeeat.document.member;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import timeeat.document.BaseDocumentTest;
+import timeeat.document.RestDocsRequest;
+import timeeat.document.Tag;
 
 public class MemberDocumentTest extends BaseDocumentTest {
 
     @Nested
     class RedirectOauthLoginPage {
 
+        RestDocsRequest requestDocument = request()
+                .tag(Tag.MEMBER_API)
+                .summary("OAuth 로그인 페이지 리다이렉트");
+
         @Test
         void Oauth_로그인_페이지로_리다이렉트_할_수_있다() {
-            var document = document("member/oauth_redirect", 302).build();
+            var document = document("member/oauth_redirect", 302)
+                    .request(requestDocument)
+                    .build();
 
             given(document)
                     .redirects().follow(false)

--- a/src/test/java/timeeat/document/member/MemberDocumentTest.java
+++ b/src/test/java/timeeat/document/member/MemberDocumentTest.java
@@ -1,0 +1,24 @@
+package timeeat.document.member;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import timeeat.document.BaseDocumentTest;
+
+public class MemberDocumentTest extends BaseDocumentTest {
+
+    @Nested
+    class RedirectOauthLoginPage {
+
+        @Test
+        void Oauth_로그인_페이지로_리다이렉트_할_수_있다() {
+            var document = document("member/oauth_redirect", 302).build();
+
+            given(document)
+                    .redirects().follow(false)
+                    .when()
+                    .get("/api/login/auth")
+                    .then()
+                    .statusCode(302);
+        }
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -8,11 +8,13 @@ spring:
   config:
     activate:
       on-profile: test
+
   datasource:
     driver-class-name: org.h2.Driver
     url: jdbc:h2:mem:database
     username: sa
     password:
+
   jpa:
     show-sql: true
     properties:
@@ -21,5 +23,10 @@ spring:
     hibernate:
       ddl-auto: create-drop
     defer-datasource-initialization: true
+
   flyway:
     enabled: false
+
+oauth:
+  clientId: abcd1234
+  redirectUri: http://localhost:3000/hello


### PR DESCRIPTION
## ✨ 개요
- Kakao 로그인 페이지로 리다이렉트하는 API 구현 (`GET /api/login/auth`)
- Kakao 를 통해 유저 정보를 가져오는 기능 구현
  - 관련 임시 API 구현(`POST /api/login`)

## 🧾 관련 이슈
closed #21 

## 🔍 참고 사항 (선택)
- local 환경에서 작동했을 때 정상작동 확인했습니다! (application.yml은 노션의 BE 문서 참고해주세요!)
    - ![image](https://github.com/user-attachments/assets/89df93a9-57b8-4ece-8040-4f6a138b8df9)
- RestClient를 사용했는데, 혹시 이해되지 않는 내용 있으시다면 언제든지 디스코드로 연락수세요!