### PR TITLE
[Feat] 서비스 인증/인가 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,11 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-gson:0.11.5'
+
     // Test
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/timeeat/config/WebConfig.java
+++ b/src/main/java/timeeat/config/WebConfig.java
@@ -1,0 +1,21 @@
+package timeeat.config;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import timeeat.controller.web.auth.AuthMemberArgumentResolver;
+import timeeat.controller.web.jwt.JwtManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final JwtManager jwtManager;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(new AuthMemberArgumentResolver(jwtManager));
+    }
+}

--- a/src/main/java/timeeat/controller/member/MemberController.java
+++ b/src/main/java/timeeat/controller/member/MemberController.java
@@ -3,6 +3,7 @@ package timeeat.controller.member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import timeeat.controller.web.jwt.JwtManager;
 
@@ -19,6 +20,16 @@ public class MemberController {
         TokenResponse response = new TokenResponse(
                 jwtManager.issueAccessToken(1L),
                 jwtManager.issueRefreshToken(1L));
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/api/member/reissue")
+    public ResponseEntity<TokenResponse> reissueToken(@RequestBody ReissueRequest request) {
+        long id = jwtManager.resolveRefreshToken(request.refreshToken());
+
+        TokenResponse response = new TokenResponse(
+                jwtManager.issueAccessToken(id),
+                jwtManager.issueRefreshToken(id));
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/timeeat/controller/member/MemberController.java
+++ b/src/main/java/timeeat/controller/member/MemberController.java
@@ -1,0 +1,24 @@
+package timeeat.controller.member;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+import timeeat.controller.web.jwt.JwtManager;
+
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final JwtManager jwtManager;
+
+    @PostMapping("/api/login")
+    public ResponseEntity<TokenResponse> login() {
+        // TODO : memberService.login() 메서드를 호출하여 로그인 처리
+
+        TokenResponse response = new TokenResponse(
+                jwtManager.issueAccessToken(1L),
+                jwtManager.issueRefreshToken(1L));
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/timeeat/controller/member/ReissueRequest.java
+++ b/src/main/java/timeeat/controller/member/ReissueRequest.java
@@ -1,0 +1,4 @@
+package timeeat.controller.member;
+
+public record ReissueRequest(String refreshToken) {
+}

--- a/src/main/java/timeeat/controller/member/TokenResponse.java
+++ b/src/main/java/timeeat/controller/member/TokenResponse.java
@@ -1,0 +1,4 @@
+package timeeat.controller.member;
+
+public record TokenResponse(String accessToken, String refreshToken) {
+}

--- a/src/main/java/timeeat/controller/web/auth/AuthMemberArgumentResolver.java
+++ b/src/main/java/timeeat/controller/web/auth/AuthMemberArgumentResolver.java
@@ -1,0 +1,35 @@
+package timeeat.controller.web.auth;
+
+import lombok.AllArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import timeeat.controller.web.jwt.JwtManager;
+
+@AllArgsConstructor
+public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtManager jwtManager;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(LoginMember.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) throws Exception {
+        String accessToken = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
+        if (accessToken == null) {
+            // TODO : BusinessException 으로 변경 - UNAUTHORIZED_MEMBER("AUTH001", "인증되지 않은 회원입니다.");
+            throw new RuntimeException("인증되지 않은 회원입니다.");
+        }
+        long memberId = jwtManager.resolveAccessToken(accessToken);
+        return new LoginMember(memberId);
+    }
+}

--- a/src/main/java/timeeat/controller/web/auth/LoginMember.java
+++ b/src/main/java/timeeat/controller/web/auth/LoginMember.java
@@ -1,0 +1,4 @@
+package timeeat.controller.web.auth;
+
+public record LoginMember(long id) {
+}

--- a/src/main/java/timeeat/controller/web/jwt/JwtManager.java
+++ b/src/main/java/timeeat/controller/web/jwt/JwtManager.java
@@ -1,0 +1,74 @@
+package timeeat.controller.web.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import java.time.Duration;
+import java.util.Date;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@EnableConfigurationProperties(JwtProperties.class)
+public class JwtManager {
+
+    private final JwtProperties jwtProperties;
+
+    public JwtManager(JwtProperties jwtProperties) {
+        this.jwtProperties = jwtProperties;
+    }
+
+    public String issueAccessToken(long id) {
+        return createToken(id, jwtProperties.getAccessTokenExpiration(), TokenType.ACCESS_TOKEN);
+    }
+
+    public String issueRefreshToken(long id) {
+        return createToken(id, jwtProperties.getRefreshTokenExpiration(), TokenType.REFRESH_TOKEN);
+    }
+
+    private String createToken(long identifier, Duration expiration, TokenType tokenType) {
+        Date now = new Date();
+        Date expired = new Date(now.getTime() + expiration.toMillis());
+        return Jwts.builder()
+                .setSubject(Long.toString(identifier))
+                .setIssuedAt(now)
+                .setExpiration(expired)
+                .claim("type", tokenType.name())
+                .signWith(jwtProperties.getSecretKey())
+                .compact();
+    }
+
+    public long resolveAccessToken(String accessToken) {
+        return resolveToken(accessToken, TokenType.ACCESS_TOKEN);
+    }
+
+    public long resolveRefreshToken(String refreshToken) {
+        return resolveToken(refreshToken, TokenType.REFRESH_TOKEN);
+    }
+
+    private long resolveToken(String token, TokenType tokenType) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(jwtProperties.getSecretKey())
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            validateTokenType(claims, tokenType);
+            return Long.parseLong(claims.getSubject());
+        } catch (ExpiredJwtException exception) {
+            // TODO : BusinessException 으로 변경 - EXPIRED_TOKEN("AUTH002", "이미 만료된 토큰입니다.");
+            throw new RuntimeException("이미 만료된 토큰입니다.");
+        } catch (Exception e) {
+            // TODO : BusinessException 으로 변경 - UNAUTHORIZED_MEMBER("AUTH001", "인증되지 않은 회원입니다.");
+            throw new RuntimeException("인증되지 않은 회원입니다.");
+        }
+    }
+
+    private void validateTokenType(Claims claims, TokenType tokenType) {
+        String extractTokenType = claims.get("type", String.class);
+        if (!extractTokenType.equals(tokenType.name())) {
+            // TODO : BusinessException 으로 변경 - UNAUTHORIZED_MEMBER("AUTH001", "인증되지 않은 회원입니다.");
+            throw new RuntimeException("인증되지 않은 회원입니다.");
+        }
+    }
+}

--- a/src/main/java/timeeat/controller/web/jwt/JwtProperties.java
+++ b/src/main/java/timeeat/controller/web/jwt/JwtProperties.java
@@ -10,7 +10,7 @@ import io.jsonwebtoken.security.Keys;
 @ConfigurationProperties(prefix = "jwt")
 public class JwtProperties {
 
-    private static final int SECRET_KEY_MIN_BYTES = 256;
+    private static final int SECRET_KEY_MIN_BYTES = 32;
 
     private final String secretKey;
     private final Duration accessTokenExpiration;
@@ -29,7 +29,7 @@ public class JwtProperties {
     private void validate(String secretKey) {
         if (secretKey == null || secretKey.getBytes().length < SECRET_KEY_MIN_BYTES) {
             // TODO Initialize error 논의
-            throw new RuntimeException("JWT secret key must be at least 256 bits");
+            throw new RuntimeException("JWT secret key must be at least 32 bytes");
         }
     }
 

--- a/src/main/java/timeeat/controller/web/jwt/JwtProperties.java
+++ b/src/main/java/timeeat/controller/web/jwt/JwtProperties.java
@@ -1,0 +1,48 @@
+package timeeat.controller.web.jwt;
+
+import java.time.Duration;
+import javax.crypto.SecretKey;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import io.jsonwebtoken.security.Keys;
+
+@Getter
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+
+    private static final int SECRET_KEY_MIN_BYTES = 256;
+
+    private final String secretKey;
+    private final Duration accessTokenExpiration;
+    private final Duration refreshTokenExpiration;
+
+    public JwtProperties(String secretKey, Duration accessTokenExpiration, Duration refreshTokenExpiration) {
+        validate(secretKey);
+        validate(accessTokenExpiration);
+        validate(refreshTokenExpiration);
+
+        this.secretKey = secretKey;
+        this.accessTokenExpiration = accessTokenExpiration;
+        this.refreshTokenExpiration = refreshTokenExpiration;
+    }
+
+    private void validate(String secretKey) {
+        if (secretKey == null || secretKey.getBytes().length < SECRET_KEY_MIN_BYTES) {
+            // TODO Initialize error 논의
+            throw new RuntimeException("JWT secret key must be at least 256 bits");
+        }
+    }
+
+    private void validate(Duration expiration) {
+        if (expiration == null) {
+            throw new RuntimeException("JWT token duration cannot be null");
+        }
+        if (expiration.isZero() || expiration.isNegative()) {
+            throw new RuntimeException("JWT token duration must be positive and non-zero");
+        }
+    }
+
+    public SecretKey getSecretKey() {
+        return Keys.hmacShaKeyFor(secretKey.getBytes());
+    }
+}

--- a/src/main/java/timeeat/controller/web/jwt/TokenType.java
+++ b/src/main/java/timeeat/controller/web/jwt/TokenType.java
@@ -1,0 +1,6 @@
+package timeeat.controller.web.jwt;
+
+public enum TokenType {
+    ACCESS_TOKEN,
+    REFRESH_TOKEN
+}

--- a/src/test/java/timeeat/controller/BaseControllerTest.java
+++ b/src/test/java/timeeat/controller/BaseControllerTest.java
@@ -1,5 +1,6 @@
 package timeeat.controller;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import timeeat.DatabaseCleaner;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import timeeat.controller.web.jwt.JwtManager;
 
 @ExtendWith(DatabaseCleaner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -19,13 +21,16 @@ public class BaseControllerTest {
 
     private static final List<Filter> SPEC_FILTERS = List.of(new RequestLoggingFilter(), new ResponseLoggingFilter());
 
+    @Autowired
+    private JwtManager jwtManager;
+
     @LocalServerPort
     private int port;
 
     private RequestSpecification spec;
 
     @BeforeEach
-    void setEnvironment() {
+    protected final void setEnvironment() {
         RestAssured.port = port;
         spec = new RequestSpecBuilder()
                 .addFilters(SPEC_FILTERS)
@@ -34,5 +39,15 @@ public class BaseControllerTest {
 
     protected final RequestSpecification given() {
         return RestAssured.given(spec);
+    }
+
+    protected final String accessToken() {
+        // TODO : 실제 회원 생성
+        return jwtManager.issueAccessToken(1L);
+    }
+
+    protected final String refreshToken() {
+        // TODO : 실제 회원 생성
+        return jwtManager.issueRefreshToken(1L);
     }
 }

--- a/src/test/java/timeeat/controller/member/MemberControllerTest.java
+++ b/src/test/java/timeeat/controller/member/MemberControllerTest.java
@@ -1,0 +1,33 @@
+package timeeat.controller.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import timeeat.controller.BaseControllerTest;
+
+class MemberControllerTest extends BaseControllerTest {
+
+    @Nested
+    class ReissueToken {
+
+        @Test
+        void 리프레시_토큰을_이용해_토큰을_재발급한다() {
+            ReissueRequest request = new ReissueRequest(refreshToken());
+
+            TokenResponse response = given().body(request)
+                    .contentType(ContentType.JSON)
+                    .when().post("/api/member/reissue")
+                    .then()
+                    .statusCode(200)
+                    .extract().as(TokenResponse.class);
+
+            assertAll(
+                    () -> assertThat(response.accessToken()).isNotBlank(),
+                    () -> assertThat(response.refreshToken()).isNotBlank()
+            );
+        }
+    }
+}

--- a/src/test/java/timeeat/controller/web/jwt/JwtManagerTest.java
+++ b/src/test/java/timeeat/controller/web/jwt/JwtManagerTest.java
@@ -1,0 +1,132 @@
+package timeeat.controller.web.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class JwtManagerTest {
+
+    private final String secretKey = "secretKey".repeat(32);
+    private final JwtManager jwtManager = new JwtManager(
+            new JwtProperties(secretKey, Duration.ofHours(1), Duration.ofDays(14)));
+
+    @Nested
+    class IssueAccessToken {
+
+        @Test
+        void 액세스_토큰을_발행할_수_있다() {
+            long id = 12345L;
+
+            assertThatCode(() -> jwtManager.issueAccessToken(id))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    class IssueRefreshToken {
+
+        @Test
+        void 액세스_토큰을_발행할_수_있다() {
+            long id = 12345L;
+
+            assertThatCode(() -> jwtManager.issueRefreshToken(id))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    class ResolveAccessToken {
+
+        @Test
+        void 액세스_토큰을_해석할_수_있다() {
+            long id = 12345L;
+            String accessToken = jwtManager.issueAccessToken(id);
+
+            long actualId = jwtManager.resolveAccessToken(accessToken);
+
+            assertThat(actualId).isEqualTo(id);
+        }
+
+        @Test
+        void 만료된_액세스_토큰을_해석하면_에러가_발생한다() {
+            Duration accessTokenExpiration = Duration.ofNanos(1);
+            JwtManager jwtManager = new JwtManager(
+                    new JwtProperties(secretKey, accessTokenExpiration, Duration.ofDays(14)));
+            long id = 12345L;
+            String accessToken = jwtManager.issueAccessToken(id);
+
+            assertThatThrownBy(() -> jwtManager.resolveAccessToken(accessToken))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("이미 만료된 토큰입니다.");
+        }
+
+        @Test
+        void 유효하지_않은_액세스_토큰을_해석하면_에러가_발생한다() {
+            String accessToken = "aaa.bbb.ccc";
+
+            assertThatThrownBy(() -> jwtManager.resolveAccessToken(accessToken))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("인증되지 않은 회원입니다.");
+        }
+
+        @Test
+        void 액세스_토큰의_타입이_다르면_에러가_발생한다() {
+            long id = 12345L;
+            String refreshToken = jwtManager.issueRefreshToken(id);
+
+            assertThatThrownBy(() -> jwtManager.resolveAccessToken(refreshToken))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("인증되지 않은 회원입니다.");
+        }
+    }
+
+    @Nested
+    class ResolveRefreshToken {
+
+        @Test
+        void 리프레시_토큰을_해석할_수_있다() {
+            long id = 12345L;
+            String refreshToken = jwtManager.issueRefreshToken(id);
+
+            long actualId = jwtManager.resolveRefreshToken(refreshToken);
+
+            assertThat(actualId).isEqualTo(id);
+        }
+
+        @Test
+        void 만료된_리프레시_토큰을_해석하면_에러가_발생한다() {
+            Duration refreshTokenExpiration = Duration.ofNanos(1);
+            JwtManager jwtManager = new JwtManager(
+                    new JwtProperties(secretKey, Duration.ofHours(1), refreshTokenExpiration));
+            long id = 12345L;
+            String refreshToken = jwtManager.issueRefreshToken(id);
+
+            assertThatThrownBy(() -> jwtManager.resolveRefreshToken(refreshToken))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("이미 만료된 토큰입니다.");
+        }
+
+        @Test
+        void 유효하지_않은_리프레시_토큰을_해석하면_에러가_발생한다() {
+            String refreshToken = "aaa.bbb.ccc";
+
+            assertThatThrownBy(() -> jwtManager.resolveRefreshToken(refreshToken))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("인증되지 않은 회원입니다.");
+        }
+
+        @Test
+        void 리프레시_토큰의_타입이_다르면_에러가_발생한다() {
+            long id = 12345L;
+            String accessToken = jwtManager.issueAccessToken(id);
+
+            assertThatThrownBy(() -> jwtManager.resolveRefreshToken(accessToken))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("인증되지 않은 회원입니다.");
+        }
+    }
+}

--- a/src/test/java/timeeat/controller/web/jwt/JwtPropertiesTest.java
+++ b/src/test/java/timeeat/controller/web/jwt/JwtPropertiesTest.java
@@ -1,5 +1,6 @@
 package timeeat.controller.web.jwt;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
@@ -19,23 +20,31 @@ class JwtPropertiesTest {
 
             assertThatThrownBy(() -> new JwtProperties(secretKey, Duration.ofMinutes(30), Duration.ofDays(14)))
                     .isInstanceOf(RuntimeException.class)
-                    .hasMessage("JWT secret key must be at least 256 bits");
+                    .hasMessage("JWT secret key must be at least 32 bytes");
         }
 
         @Test
         void 비밀키가_특정_길이보다_짧으면_예외를_발생시킨다() {
-            String secretKey = "1".repeat(255); // 255 bytes
+            String secretKey = "1".repeat(31); // 31 bytes
 
             assertThatThrownBy(() -> new JwtProperties(secretKey, Duration.ofMinutes(30), Duration.ofDays(14)))
                     .isInstanceOf(RuntimeException.class)
-                    .hasMessage("JWT secret key must be at least 256 bits");
+                    .hasMessage("JWT secret key must be at least 32 bytes");
+        }
+
+        @Test
+        void 비밀키가_특정_길이보다_길면_정상적으로_생성된다() {
+            String secretKey = "1".repeat(32); // 32 bytes
+
+            assertThatCode(() -> new JwtProperties(secretKey, Duration.ofMinutes(30), Duration.ofDays(14)))
+                    .doesNotThrowAnyException();
         }
     }
 
     @Nested
     class ValidateExpiration {
 
-        private final String secretKey = "validSecretKey".repeat(32);
+        private final String secretKey = "validSecretKey".repeat(8);
 
         @Test
         void 만료기간이_비어있으면_예외를_발생시킨다() {

--- a/src/test/java/timeeat/controller/web/jwt/JwtPropertiesTest.java
+++ b/src/test/java/timeeat/controller/web/jwt/JwtPropertiesTest.java
@@ -1,0 +1,54 @@
+package timeeat.controller.web.jwt;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+class JwtPropertiesTest {
+
+    @Nested
+    class ValidateSecretKey {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void 비밀키가_비어있으면_예외를_발생시킨다(String secretKey) {
+
+            assertThatThrownBy(() -> new JwtProperties(secretKey, Duration.ofMinutes(30), Duration.ofDays(14)))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("JWT secret key must be at least 256 bits");
+        }
+
+        @Test
+        void 비밀키가_특정_길이보다_짧으면_예외를_발생시킨다() {
+            String secretKey = "1".repeat(255); // 255 bytes
+
+            assertThatThrownBy(() -> new JwtProperties(secretKey, Duration.ofMinutes(30), Duration.ofDays(14)))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("JWT secret key must be at least 256 bits");
+        }
+    }
+
+    @Nested
+    class ValidateExpiration {
+
+        private final String secretKey = "validSecretKey".repeat(32);
+
+        @Test
+        void 만료기간이_비어있으면_예외를_발생시킨다() {
+            assertThatThrownBy(() -> new JwtProperties(secretKey, null, Duration.ofDays(14)))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("JWT token duration cannot be null");
+        }
+
+        @Test
+        void 만료기간이_0이거나_음수이면_예외를_발생시킨다() {
+            assertThatThrownBy(() -> new JwtProperties(secretKey, Duration.ofHours(1), Duration.ZERO))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("JWT token duration must be positive and non-zero");
+        }
+    }
+}

--- a/src/test/java/timeeat/document/BaseDocumentTest.java
+++ b/src/test/java/timeeat/document/BaseDocumentTest.java
@@ -6,6 +6,7 @@ import io.restassured.specification.RequestSpecification;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.restdocs.RestDocumentationContextProvider;
@@ -13,12 +14,16 @@ import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.restassured.RestAssuredRestDocumentation;
 import org.springframework.restdocs.restassured.RestAssuredRestDocumentationConfigurer;
 import org.springframework.restdocs.restassured.RestDocumentationFilter;
+import timeeat.controller.web.jwt.JwtManager;
 
 @ExtendWith({RestDocumentationExtension.class, MockitoExtension.class})
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public abstract class BaseDocumentTest {
 
     // @MockitoBean 을 이용하여 Service Layer 및 특정 객체 Mocking
+
+    @Autowired
+    private JwtManager jwtManager;
 
     @LocalServerPort
     private int port;
@@ -48,8 +53,16 @@ public abstract class BaseDocumentTest {
         return new RestDocsFilterBuilder(identifierPrefix, Integer.toString(statusCode));
     }
 
-    protected RequestSpecification given(RestDocumentationFilter documentationFilter) {
+    protected final RequestSpecification given(RestDocumentationFilter documentationFilter) {
         return RestAssured.given(spec)
                 .filter(documentationFilter);
+    }
+
+    protected final String accessToken() {
+        return jwtManager.issueAccessToken(1L);
+    }
+
+    protected final String refreshToken() {
+        return jwtManager.issueRefreshToken(1L);
     }
 }

--- a/src/test/java/timeeat/document/Tag.java
+++ b/src/test/java/timeeat/document/Tag.java
@@ -2,7 +2,7 @@ package timeeat.document;
 
 public enum Tag {
 
-    MEMBER_API("Member API"), // Example (추후 삭제)
+    MEMBER_API("Member API"),
     ;
 
     private final String displayName;

--- a/src/test/java/timeeat/document/member/MemberDocumentTest.java
+++ b/src/test/java/timeeat/document/member/MemberDocumentTest.java
@@ -1,0 +1,51 @@
+package timeeat.document.member;
+
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import timeeat.controller.member.ReissueRequest;
+import timeeat.document.BaseDocumentTest;
+import timeeat.document.RestDocsRequest;
+import timeeat.document.RestDocsResponse;
+import timeeat.document.Tag;
+
+
+public class MemberDocumentTest extends BaseDocumentTest {
+
+    @Nested
+    class ReissueToken {
+
+        private final RestDocsRequest requestDocument = request()
+                .tag(Tag.MEMBER_API)
+                .summary("토큰 재발급")
+                .requestBodyField(
+                        fieldWithPath("refreshToken").type(STRING).description("리프레시 토큰")
+                );
+
+        private final RestDocsResponse responseDocument = response()
+                .responseBodyField(
+                        fieldWithPath("accessToken").type(STRING).description("액세스 토큰"),
+                        fieldWithPath("refreshToken").type(STRING).description("리프레시 토큰")
+                );
+
+        @Test
+        void 토큰_재발급_성공() {
+            ReissueRequest request = new ReissueRequest(refreshToken());
+
+            var document = document("member/reissue", 200)
+                    .request(requestDocument)
+                    .response(responseDocument)
+                    .build();
+
+            given(document)
+                    .contentType(ContentType.JSON)
+                    .body(request)
+                    .when().post("/api/member/reissue")
+                    .then().statusCode(200);
+        }
+
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -23,3 +23,7 @@ spring:
     defer-datasource-initialization: true
   flyway:
     enabled: false
+jwt:
+  secret-key: test-secret-key-test-secret-key-test-key-test-secret-key-test
+  access-token-expiration: 1h
+  refresh-token-expiration: 1d


### PR DESCRIPTION
## ✨ 개요
- 로그인 시, 인가 기능 구현 (리프레시 토큰과 액세스 토큰 전달)
- 리프레시 토큰을 통한 토큰 재발급 기능 구현
- `LoginMember` 를 통한 인증 기능 구현
    - Controller 구현 시, 인자로 `LoginMember`을 사용하면 인증 절차가 처리됨
    - 해당 객체를 통해 로그인 한 유저의 id값을 알 수 있음

## 🧾 관련 이슈
closed #22 

## 🔍 참고 사항 (선택)
- 이전에 base branch 를 main으로 올려서 PR 다시 올렸습니다!