### PR TITLE
[Fix] Oauth Redirect URL을 여러 개를 사용할 수 있도록 수정

### DIFF
--- a/src/main/java/timeeat/client/oauth/OauthProperties.java
+++ b/src/main/java/timeeat/client/oauth/OauthProperties.java
@@ -1,14 +1,68 @@
 package timeeat.client.oauth;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import lombok.AllArgsConstructor;
+import java.net.URI;
+import java.util.List;
 import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Getter
-@AllArgsConstructor
 @ConfigurationProperties(prefix = "oauth")
 public class OauthProperties {
 
     private final String clientId;
-    private final String redirectUri;
+    private final String redirectPath;
+    private final List<String> allowedOrigins;
+
+    public OauthProperties(String clientId, String redirectPath, List<String> allowedOrigins) {
+        validateClientId(clientId);
+        validateRedirectPath(redirectPath);
+        validateOrigins(allowedOrigins);
+
+        this.clientId = clientId;
+        this.redirectPath = redirectPath;
+        this.allowedOrigins = allowedOrigins;
+    }
+
+    private void validateClientId(String clientId) {
+        if (clientId == null || clientId.isBlank()) {
+            // TODO InitializeException 을 이용
+            throw new RuntimeException("Client ID must not be null or empty");
+        }
+    }
+
+    private void validateRedirectPath(String redirectPath) {
+        if (redirectPath == null || !redirectPath.startsWith("/")) {
+            // TODO InitializeException 을 이용
+            throw new RuntimeException("Redirect path must not be null or start with '/'");
+        }
+    }
+
+    private void validateOrigins(List<String> origins) {
+        if (origins == null || origins.isEmpty()) {
+            // TODO InitializeException 을 이용
+            throw new RuntimeException("Allowed origins must not be null or empty");
+        }
+        origins.forEach(this::validateOrigin);
+    }
+
+    private void validateOrigin(String origin) {
+        URI uri;
+        try {
+            uri = new URI(origin);
+        } catch (Exception e) {
+            // TODO InitializeException 을 이용
+            throw new RuntimeException("Allowed origin must be a valid origin form: " + origin, e);
+        }
+
+        if (uri.getScheme() == null || uri.getHost() == null || !uri.getPath().isBlank()) {
+            // TODO InitializeException 을 이용
+            System.out.println("Path: " + uri.getPath());
+            throw new RuntimeException("Allowed origin must be a valid origin form: " + origin);
+        }
+    }
+
+    public boolean isAllowedOrigin(String origin) {
+        return allowedOrigins.stream()
+                .anyMatch(allowedOrigin -> allowedOrigin.equalsIgnoreCase(origin.trim()));
+    }
 }

--- a/src/main/java/timeeat/controller/auth/AuthController.java
+++ b/src/main/java/timeeat/controller/auth/AuthController.java
@@ -1,11 +1,13 @@
 package timeeat.controller.auth;
 
 import java.net.URI;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 import timeeat.controller.web.jwt.JwtManager;
@@ -19,8 +21,8 @@ public class AuthController {
     private final AuthService authService;
 
     @GetMapping("/api/auth/login/oauth")
-    public ResponseEntity<Void> redirectOauthLoginPage() {
-        URI oauthLoginUrl = authService.getOauthLoginUrl();
+    public ResponseEntity<Void> redirectOauthLoginPage(@RequestHeader(HttpHeaders.ORIGIN) String origin) {
+        URI oauthLoginUrl = authService.getOauthLoginUrl(origin);
 
         return ResponseEntity
                 .status(HttpStatus.FOUND)

--- a/src/main/java/timeeat/exception/BusinessErrorCode.java
+++ b/src/main/java/timeeat/exception/BusinessErrorCode.java
@@ -41,6 +41,7 @@ public enum BusinessErrorCode {
     // Auth
     UNAUTHORIZED_MEMBER("AUTH001", "인증되지 않은 회원입니다."),
     EXPIRED_TOKEN("AUTH002", "이미 만료된 토큰입니다."),
+    UNAUTHORIZED_ORIGIN("AUTH003", "허용되지 않은 오리진입니다."),
     ;
 
     private final String code;

--- a/src/main/java/timeeat/service/auth/AuthService.java
+++ b/src/main/java/timeeat/service/auth/AuthService.java
@@ -16,8 +16,8 @@ public class AuthService {
 
     private final OauthClient oauthClient;
 
-    public URI getOauthLoginUrl() {
-        return oauthClient.getOauthLoginUrl();
+    public URI getOauthLoginUrl(String origin) {
+        return oauthClient.getOauthLoginUrl(origin);
     }
 
     public void login(MemberLoginRequest request) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -28,9 +28,18 @@ spring:
       - classpath:db/seed/dev
 
 jwt:
+  access-token-expiration: 1h
+  refresh-token-expiration: 14d
   secret-key: ${JWT_SECRET_KEY}
 
 cors:
   origin:
     - "http://localhost:3000"
     - "https://api-dev.eatda.net"
+
+oauth:
+  client-id: ${OAUTH_CLIENT_ID}
+  redirect-path: /login/callback
+  allowed-origins:
+    - "http://localhost:3000"
+    - "https://dev.eatda.net"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -21,8 +21,16 @@ spring:
       - classpath:db/seed/local
 
 jwt:
-  secret-key: ${LOCAL_JWT_SECRET_KEY}
+  access-token-expiration: 1h
+  refresh-token-expiration: 1d
+  secret-key: ${JWT_SECRET_KEY}
 
 cors:
   origin:
+    - "http://localhost:3000"
+
+oauth:
+  client-id: ${OAUTH_CLIENT_ID}
+  redirect-path: /login/callback
+  allowed-origins:
     - "http://localhost:3000"

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -28,9 +28,18 @@ spring:
       - classpath:db/seed/prod
 
 jwt:
+  access-token-expiration: 1h
+  refresh-token-expiration: 14d
   secret-key: ${JWT_SECRET_KEY}
 
 cors:
   origin:
+    - "https://www.eatda.net"
+    - "https://eatda.net"
+
+oauth:
+  client-id: ${OAUTH_CLIENT_ID}
+  redirect-path: /login/callback
+  allowed-origins:
     - "https://www.eatda.net"
     - "https://eatda.net"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,3 @@ springdoc:
     persist-authorization: true
     display-request-duration: true
     default-model-expand-depth: 10
-
-jwt:
-  access-token-expiration: 1h
-  refresh-token-expiration: 1d

--- a/src/test/java/timeeat/client/oauth/OauthPropertiesTest.java
+++ b/src/test/java/timeeat/client/oauth/OauthPropertiesTest.java
@@ -1,0 +1,67 @@
+package timeeat.client.oauth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class OauthPropertiesTest {
+
+    @Nested
+    class Validate {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void 클라이언트_아이디가_비어있는_경우_예외를_던진다(String clientId) {
+            assertThatThrownBy(() -> new OauthProperties(clientId, "/path", List.of("http://localhost:8080")))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("Client ID must not be null or empty");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"path", ".path", "path/", ""})
+        void 리다이렉트_경로가_경로_형식이_아닌_경우_예외를_던진다(String redirectPath) {
+            assertThatThrownBy(() -> new OauthProperties("client-id", redirectPath, List.of("http://localhost:8080")))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("Redirect path must not be null or start with '/'");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"invalid-url", "http://", "http://:8080", "http://localhost:8080/path", " "})
+        void 허용된_오리진이_유효하지_않은_URL인_경우_예외를_던진다(String origin) {
+            assertThatThrownBy(() -> new OauthProperties("client-id", "/path", List.of(origin)))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("Allowed origin must be a valid origin form");
+        }
+    }
+
+    @Nested
+    class IsAllowedOrigin {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"http://localhost:8080", " http://localhost:8080 ", "https://example.com"})
+        void 허용된_오리진인_경우_true를_반환한다(String allowedOrigin) {
+            List<String> origins = List.of("http://localhost:8080", "https://example.com");
+            OauthProperties oauthProperties = new OauthProperties("client-id", "/path", origins);
+
+            boolean isAllowed = oauthProperties.isAllowedOrigin(allowedOrigin);
+
+            assertThat(isAllowed).isTrue();
+        }
+
+        @Test
+        void 허용되지_않은_오리진인_경우_false를_반환한다() {
+            OauthProperties oauthProperties = new OauthProperties("client-id", "/path",
+                    List.of("http://localhost:8080"));
+
+            boolean isAllowed = oauthProperties.isAllowedOrigin("https://not-allowed.com");
+
+            assertThat(isAllowed).isFalse();
+        }
+    }
+}

--- a/src/test/java/timeeat/controller/auth/AuthControllerTest.java
+++ b/src/test/java/timeeat/controller/auth/AuthControllerTest.java
@@ -3,11 +3,11 @@ package timeeat.controller.auth;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import io.restassured.http.ContentType;
+import org.springframework.http.HttpHeaders;
 import timeeat.controller.BaseControllerTest;
 
 class AuthControllerTest extends BaseControllerTest {
@@ -15,15 +15,22 @@ class AuthControllerTest extends BaseControllerTest {
     @Nested
     class RedirectOauthLoginPage {
 
-        @Value("${oauth.clientId}")
+        @Value("${oauth.client-id}")
         private String clientId;
 
-        @Value("${oauth.redirectUri}")
-        private String redirectUri;
+        @Value("${oauth.redirect-path}")
+        private String redirectPath;
+
+        @Value("${oauth.allowed-origins[0]}")
+        private String allowedOrigin;
 
         @Test
         void Oauth_로그인_페이지로_리다이렉트_할_수_있다() {
+            String origin = allowedOrigin;
+            String expectedRedirectPath = origin + redirectPath;
+
             String location = given()
+                    .header(HttpHeaders.ORIGIN, origin)
                     .redirects().follow(false)
                     .when()
                     .get("/api/auth/login/oauth")
@@ -34,7 +41,7 @@ class AuthControllerTest extends BaseControllerTest {
             assertThat(location)
                     .contains("https://kauth.kakao.com/oauth/authorize")
                     .contains("client_id=%s".formatted(clientId))
-                    .contains("redirect_uri=%s".formatted(redirectUri))
+                    .contains("redirect_uri=%s".formatted(expectedRedirectPath))
                     .contains("response_type=code");
         }
     }

--- a/src/test/java/timeeat/document/auth/AuthDocumentTest.java
+++ b/src/test/java/timeeat/document/auth/AuthDocumentTest.java
@@ -4,10 +4,11 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.headerWit
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
+import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
-import io.restassured.http.ContentType;
 import timeeat.controller.auth.ReissueRequest;
 import timeeat.document.BaseDocumentTest;
 import timeeat.document.RestDocsRequest;
@@ -19,9 +20,15 @@ public class AuthDocumentTest extends BaseDocumentTest {
     @Nested
     class RedirectOauthLoginPage {
 
+        @Value("${oauth.allowed-origins[0]}")
+        private String origin;
+
         RestDocsRequest requestDocument = request()
                 .tag(Tag.MEMBER_API)
-                .summary("OAuth 로그인 페이지 리다이렉트");
+                .summary("OAuth 로그인 페이지 리다이렉트")
+                .requestHeader(
+                        headerWithName(HttpHeaders.ORIGIN).description("요청 Origin")
+                );
 
         RestDocsResponse responseDocument = response()
                 .responseHeader(
@@ -37,6 +44,7 @@ public class AuthDocumentTest extends BaseDocumentTest {
 
             given(document)
                     .redirects().follow(false)
+                    .header(HttpHeaders.ORIGIN, origin)
                     .when()
                     .get("/api/auth/login/oauth")
                     .then()

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -32,10 +32,6 @@ spring:
     init:
       mode: never
 
-oauth:
-  clientId: abcd1234
-  redirectUri: http://localhost:3000/hello
-
 cors:
   origin: "https://example.eat-da.com"
 
@@ -43,3 +39,9 @@ jwt:
   secret-key: ${TEST_JWT_SECRET_KEY}
   access-token-expiration: 1h
   refresh-token-expiration: 1d
+
+oauth:
+  client-id: abcd1234
+  redirect-path: /callback
+  allowed-origins:
+    - http://localhost:3000

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -44,4 +44,4 @@ oauth:
   client-id: abcd1234
   redirect-path: /callback
   allowed-origins:
-    - http://localhost:3000
+    - "https://example.eat-da.com"


### PR DESCRIPTION
## ✨ 개요
- oauth 관련 외부 설정 값의 유효성 검증 추가
- Http Request Header의 Origin 값에 따라, Redirect Location의 쿼리 파라미터 "redirect_uri"의 주소가 가변적으로 바뀌게 구현

## 🧾 관련 이슈
closed #36 

## 🔍 참고 사항 (선택)
1. JWT 설정 사항은 일부는 공통, 일부는 (환경별로) 따로 관리하는 것보다, 전부 따로 관리하는 것이 좋을 것 같아 분리했습니다
2. 현재 cors.origins 와 oauth.allowed-origin 은 항상 같은 값이지만 일단 분리했습니다. 더 좋은 의견 있으시면 반영하도록 하겠습니다!