### PR TITLE
[Chore] Route53과 Vercel 도메인 연동 작업

### DIFF
--- a/terraform/common/locals.tf
+++ b/terraform/common/locals.tf
@@ -100,6 +100,12 @@ locals {
     api     = local.alb_alias
     api-dev = local.alb_alias
   }
+
+  frontend_domains = {
+    "eatda.net" = { type = "A", value = "76.76.21.21" }
+    "www" = { type = "CNAME", value = "cname.vercel-dns.com" }
+    "dev" = { type = "CNAME", value = "cname.vercel-dns.com" }
+  }
 }
 
 locals {

--- a/terraform/common/main.tf
+++ b/terraform/common/main.tf
@@ -37,6 +37,7 @@ module "route53" {
   validation_method = local.validation_method
   record_type       = local.record_type
   subdomains        = local.subdomains
+  frontend_domains  = local.frontend_domains
 }
 
 module "alb" {

--- a/terraform/common/route53/main.tf
+++ b/terraform/common/route53/main.tf
@@ -55,7 +55,7 @@ resource "aws_route53_record" "frontend_subdomains" {
   for_each = var.frontend_domains
 
   zone_id = data.aws_route53_zone.common.zone_id
-  name    = each.key == "eatda.net" ? var.domain_name : "${each.key}.${var.domain_name}"
+  name    = each.key == var.domain_name ? var.domain_name : "${each.key}.${var.domain_name}"
   type    = each.value.type
 
   ttl = 300

--- a/terraform/common/route53/main.tf
+++ b/terraform/common/route53/main.tf
@@ -50,3 +50,14 @@ resource "aws_route53_record" "subdomains" {
     evaluate_target_health = true
   }
 }
+
+resource "aws_route53_record" "frontend_subdomains" {
+  for_each = var.frontend_domains
+
+  zone_id = data.aws_route53_zone.common.zone_id
+  name    = each.key == "eatda.net" ? var.domain_name : "${each.key}.${var.domain_name}"
+  type    = each.value.type
+
+  ttl = 300
+  records = [each.value.value]
+}

--- a/terraform/common/route53/variables.tf
+++ b/terraform/common/route53/variables.tf
@@ -11,6 +11,14 @@ variable "subdomains" {
   }))
 }
 
+variable "frontend_domains" {
+  description = "frontend domains (A record or CNAME)"
+  type = map(object({
+    type  = string
+    value = string
+  }))
+}
+
 variable "validation_method" {
   type = string
 }


### PR DESCRIPTION
## ✨ 개요
- Route53에 Versel A record, CNAME을 추가하였습니다.

## 🧾 관련 이슈
#41 

## 🔍 참고 사항 (선택)

아래 도메인 둘 다 잘 연동되었습니다.
www.eatda.net
eatda.net

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 프론트엔드 도메인(eatda.net, www, dev)에 대한 DNS 레코드(A, CNAME) 자동 생성 기능이 추가되었습니다.  
  * 다양한 도메인 및 레코드 타입을 손쉽게 관리할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->