### PR TITLE
[Test] 로그인 API 테스트 케이스 추가 및 Rest Docs 문서 수정

### DIFF
--- a/src/main/java/timeeat/controller/auth/AuthController.java
+++ b/src/main/java/timeeat/controller/auth/AuthController.java
@@ -31,10 +31,9 @@ public class AuthController {
                 .build();
     }
 
-    // TODO : login() ControllerTest, DocumentTest 수정
     @PostMapping("/api/auth/login")
-    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request,
-                                               @RequestHeader(HttpHeaders.ORIGIN) String origin) {
+    public ResponseEntity<LoginResponse> login(@RequestHeader(HttpHeaders.ORIGIN) String origin,
+                                               @RequestBody LoginRequest request) {
         MemberResponse member = authService.login(request, origin);
         TokenResponse token = new TokenResponse(
                 jwtManager.issueAccessToken(member.id()),

--- a/src/test/java/timeeat/controller/BaseControllerTest.java
+++ b/src/test/java/timeeat/controller/BaseControllerTest.java
@@ -82,4 +82,8 @@ public class BaseControllerTest {
         Member member = memberGenerator.generate(Long.toString(DEFAULT_OAUTH_MEMBER_INFO.socialId()));
         return jwtManager.issueRefreshToken(member.getId());
     }
+
+    protected final String oauthLoginSocialId() {
+        return Long.toString(DEFAULT_OAUTH_MEMBER_INFO.socialId());
+    }
 }

--- a/src/test/java/timeeat/controller/auth/AuthControllerTest.java
+++ b/src/test/java/timeeat/controller/auth/AuthControllerTest.java
@@ -46,7 +46,7 @@ class AuthControllerTest extends BaseControllerTest {
     class Login {
 
         @Test
-        void 인가코드를_통해_로그인할_수_있다() {
+        void 인가코드를_통해_회원가입할_수_있다() {
             LoginRequest request = new LoginRequest("auth-code");
 
             LoginResponse response = given().body(request)
@@ -61,6 +61,26 @@ class AuthControllerTest extends BaseControllerTest {
                     () -> assertThat(response.token().accessToken()).isNotBlank(),
                     () -> assertThat(response.token().refreshToken()).isNotBlank(),
                     () -> assertThat(response.information().isSignUp()).isTrue()
+            );
+        }
+
+        @Test
+        void 인가코드를_통해_로그인할_수_있다() {
+            memberGenerator.generate(oauthLoginSocialId());
+            LoginRequest request = new LoginRequest("auth-code");
+
+            LoginResponse response = given().body(request)
+                    .header(HttpHeaders.ORIGIN, allowedOrigin)
+                    .contentType(ContentType.JSON)
+                    .when().post("/api/auth/login")
+                    .then()
+                    .statusCode(201)
+                    .extract().as(LoginResponse.class);
+
+            assertAll(
+                    () -> assertThat(response.token().accessToken()).isNotBlank(),
+                    () -> assertThat(response.token().refreshToken()).isNotBlank(),
+                    () -> assertThat(response.information().isSignUp()).isFalse()
             );
         }
     }

--- a/src/test/java/timeeat/document/auth/AuthDocumentTest.java
+++ b/src/test/java/timeeat/document/auth/AuthDocumentTest.java
@@ -70,6 +70,9 @@ public class AuthDocumentTest extends BaseDocumentTest {
         RestDocsRequest requestDocument = request()
                 .tag(Tag.AUTH_API)
                 .summary("로그인")
+                .requestHeader(
+                        headerWithName(HttpHeaders.ORIGIN).description("요청 Origin")
+                )
                 .requestBodyField(
                         fieldWithPath("code").type(STRING).description("Oauth 인가 코드")
                 );

--- a/src/test/java/timeeat/document/member/MemberDocumentTest.java
+++ b/src/test/java/timeeat/document/member/MemberDocumentTest.java
@@ -18,6 +18,7 @@ import timeeat.controller.member.MemberUpdateRequest;
 import timeeat.document.BaseDocumentTest;
 import timeeat.document.RestDocsRequest;
 import timeeat.document.RestDocsResponse;
+import timeeat.document.Tag;
 
 public class MemberDocumentTest extends BaseDocumentTest {
 
@@ -25,6 +26,8 @@ public class MemberDocumentTest extends BaseDocumentTest {
     class updateMember {
 
         RestDocsRequest requestDocument = request()
+                .tag(Tag.MEMBER_API)
+                .summary("회원 정보 수정")
                 .requestHeader(
                         headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
                 ).requestBodyField(


### PR DESCRIPTION
## ✨ 개요
- 로그인 API에서 회원 가입, 로그인 경우를 나누어 테스트 실시
- Rest Docs에서 누락된 요소 추가

## 🧾 관련 이슈

## 🔍 참고 사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 기존 로그인 테스트 메서드명을 회원가입 테스트로 변경하고, 기존 회원의 로그인 테스트 메서드를 추가했습니다.
  * OAuth 로그인 관련 테스트 유틸리티 메서드를 추가했습니다.

* **문서화**
  * 로그인 API 요청에 "Origin" 헤더에 대한 문서가 추가되었습니다.
  * 회원 정보 수정 API 문서에 태그와 요약 설명이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->