### PR TITLE
[Feat] 닉네임, 전화번호 중복 확인 API 구현

### DIFF
--- a/src/main/java/timeeat/controller/member/MemberController.java
+++ b/src/main/java/timeeat/controller/member/MemberController.java
@@ -3,8 +3,10 @@ package timeeat.controller.member;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import timeeat.controller.web.auth.LoginMember;
 import timeeat.service.service.MemberService;
@@ -14,6 +16,18 @@ import timeeat.service.service.MemberService;
 public class MemberController {
 
     private final MemberService memberService;
+
+    @GetMapping("/api/member/nickname/check")
+    public ResponseEntity<Void> checkNickname(LoginMember member, @RequestParam String nickname) {
+        memberService.validateNickname(nickname, member.id());
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/api/member/phone-number/check")
+    public ResponseEntity<Void> checkPhoneNumber(LoginMember member, @RequestParam String phoneNumber) {
+        memberService.validatePhoneNumber(phoneNumber, member.id());
+        return ResponseEntity.noContent().build();
+    }
 
     @PutMapping("/api/member")
     public ResponseEntity<MemberResponse> updateMember(LoginMember member,

--- a/src/main/java/timeeat/exception/EtcErrorCode.java
+++ b/src/main/java/timeeat/exception/EtcErrorCode.java
@@ -13,7 +13,8 @@ public enum EtcErrorCode {
     MEDIA_TYPE_NOT_SUPPORTED("CLIENT005", "허용되지 않은 미디어 타입입니다.", HttpStatus.UNSUPPORTED_MEDIA_TYPE),
     NO_RESOURCE_FOUND("CLIENT006", "요청한 리소스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     NO_COOKIE_FOUND("CLIENT007", "필수 쿠키 값이 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
-    NO_HEADER_FOUND("CLIENT007", "필수 헤더 값이 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
+    NO_HEADER_FOUND("CLIENT008", "필수 헤더 값이 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
+    NO_PARAMETER_FOUND("CLIENT009", "필수 파라미터 값이 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
 
     INTERNAL_SERVER_ERROR("SERVER001", "서버 내부 에러가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     ;

--- a/src/main/java/timeeat/exception/GlobalExceptionHandler.java
+++ b/src/main/java/timeeat/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -66,6 +67,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MissingRequestHeaderException.class)
     public ResponseEntity<ErrorResponse> handleMissingRequestHeaderException(MissingRequestHeaderException exception) {
         return toErrorResponse(EtcErrorCode.NO_HEADER_FOUND);
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(
+            MissingServletRequestParameterException exception) {
+        return toErrorResponse(EtcErrorCode.NO_PARAMETER_FOUND);
     }
 
     @ExceptionHandler(BusinessException.class)

--- a/src/main/java/timeeat/service/service/MemberService.java
+++ b/src/main/java/timeeat/service/service/MemberService.java
@@ -16,6 +16,18 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
+    @Transactional(readOnly = true)
+    public void validateNickname(String nickname, long memberId) {
+        Member member = memberRepository.getById(memberId);
+        validateNicknameNotDuplicate(member, nickname);
+    }
+
+    @Transactional(readOnly = true)
+    public void validatePhoneNumber(String phoneNumber, long memberId) {
+        Member member = memberRepository.getById(memberId);
+        validatePhoneNumberNotDuplicate(member, phoneNumber);
+    }
+
     @Transactional
     public MemberResponse update(long memberId, MemberUpdateRequest request) {
         Member member = memberRepository.getById(memberId);

--- a/src/test/java/timeeat/controller/BaseControllerTest.java
+++ b/src/test/java/timeeat/controller/BaseControllerTest.java
@@ -35,7 +35,7 @@ public class BaseControllerTest {
 
     private static final OauthToken DEFAULT_OAUTH_TOKEN = new OauthToken("oauth-access-token");
     private static final OauthMemberInformation DEFAULT_OAUTH_MEMBER_INFO =
-            new OauthMemberInformation(123L, "nickname");
+            new OauthMemberInformation(314159248183772L, "nickname");
 
     @LocalServerPort
     private int port;

--- a/src/test/java/timeeat/controller/member/MemberControllerTest.java
+++ b/src/test/java/timeeat/controller/member/MemberControllerTest.java
@@ -12,6 +12,59 @@ import timeeat.controller.BaseControllerTest;
 class MemberControllerTest extends BaseControllerTest {
 
     @Nested
+    class CheckNickname {
+
+        @Test
+        void 중복되지_않는_닉네임을_확인할_수_있다() {
+            given()
+                    .header(HttpHeaders.AUTHORIZATION, accessToken())
+                    .queryParam("nickname", "new-nickname")
+                    .when().get("/api/member/nickname/check")
+                    .then()
+                    .statusCode(204);
+        }
+
+        @Test
+        void 중복된_닉네임을_확인할_수_있다() {
+            String existingNickname = "existing-nickname";
+            memberGenerator.generateRegisteredMember("123", existingNickname, "01012345678");
+
+            given()
+                    .header(HttpHeaders.AUTHORIZATION, accessToken())
+                    .queryParam("nickname", existingNickname)
+                    .when().get("/api/member/nickname/check")
+                    .then()
+                    .statusCode(400);
+        }
+    }
+
+    @Nested
+    class CheckPhoneNumber {
+
+        @Test
+        void 중복되지_않는_전화번호를_확인할_수_있다() {
+            given()
+                    .header(HttpHeaders.AUTHORIZATION, accessToken())
+                    .queryParam("phoneNumber", "01098765432")
+                    .when().get("/api/member/phone-number/check")
+                    .then()
+                    .statusCode(204);
+        }
+
+        @Test
+        void 중복된_전화번호를_확인할_수_있다() {
+            String existingPhoneNumber = "01012345678";
+            memberGenerator.generateRegisteredMember("123", "nickname", existingPhoneNumber);
+            given()
+                    .header(HttpHeaders.AUTHORIZATION, accessToken())
+                    .queryParam("phoneNumber", existingPhoneNumber)
+                    .when().get("/api/member/phone-number/check")
+                    .then()
+                    .statusCode(400);
+        }
+    }
+
+    @Nested
     class UpdateMember {
 
         @Test

--- a/src/test/java/timeeat/document/auth/AuthDocumentTest.java
+++ b/src/test/java/timeeat/document/auth/AuthDocumentTest.java
@@ -49,7 +49,7 @@ public class AuthDocumentTest extends BaseDocumentTest {
         void Oauth_로그인_페이지로_리다이렉트_할_수_있다() throws URISyntaxException {
             doReturn(new URI("http://localhost:8080")).when(authService).getOauthLoginUrl(anyString());
 
-            var document = document("auth/oauth_redirect", 302)
+            var document = document("auth/oauth-redirect", 302)
                     .request(requestDocument)
                     .response(responseDocument)
                     .build();

--- a/src/test/java/timeeat/document/member/MemberDocumentTest.java
+++ b/src/test/java/timeeat/document/member/MemberDocumentTest.java
@@ -1,13 +1,16 @@
 package timeeat.document.member;
 
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Nested;
@@ -18,11 +21,70 @@ import timeeat.controller.member.MemberUpdateRequest;
 import timeeat.document.BaseDocumentTest;
 import timeeat.document.RestDocsRequest;
 import timeeat.document.RestDocsResponse;
+import timeeat.document.Tag;
 
 public class MemberDocumentTest extends BaseDocumentTest {
 
     @Nested
-    class updateMember {
+    class CheckNickname {
+
+        RestDocsRequest requestDocument = request()
+                .tag(Tag.MEMBER_API)
+                .summary("닉네임 중복 검사")
+                .requestHeader(
+                        headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                ).queryParameter(
+                        parameterWithName("nickname").description("검사할 닉네임")
+                );
+
+        @Test
+        void 중복되지_않는_닉네임을_확인할_수_있다() {
+            doNothing().when(memberService).validateNickname(anyString(), anyLong());
+
+            var document = document("member/nickname-check", 204)
+                    .request(requestDocument)
+                    .build();
+
+            given(document)
+                    .contentType(ContentType.JSON)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken())
+                    .queryParam("nickname", "new-nickname")
+                    .when().get("/api/member/nickname/check")
+                    .then().statusCode(204);
+        }
+    }
+
+    @Nested
+    class CheckPhoneNumber {
+
+        RestDocsRequest requestDocument = request()
+                .tag(Tag.MEMBER_API)
+                .summary("전화번호 중복 검사")
+                .requestHeader(
+                        headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                ).queryParameter(
+                        parameterWithName("phoneNumber").description("검사할 전화번호 ex) 01012345678")
+                );
+
+        @Test
+        void 중복되지_않는_전화번호를_확인할_수_있다() {
+            doNothing().when(memberService).validatePhoneNumber(anyString(), anyLong());
+
+            var document = document("member/phone-number-check", 204)
+                    .request(requestDocument)
+                    .build();
+
+            given(document)
+                    .contentType(ContentType.JSON)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken())
+                    .queryParam("phoneNumber", "01098765432")
+                    .when().get("/api/member/phone-number/check")
+                    .then().statusCode(204);
+        }
+    }
+
+    @Nested
+    class UpdateMember {
 
         RestDocsRequest requestDocument = request()
                 .requestHeader(

--- a/src/test/java/timeeat/fixture/MemberGenerator.java
+++ b/src/test/java/timeeat/fixture/MemberGenerator.java
@@ -2,10 +2,13 @@ package timeeat.fixture;
 
 import org.springframework.stereotype.Component;
 import timeeat.domain.member.Member;
+import timeeat.enums.InterestArea;
 import timeeat.repository.member.MemberRepository;
 
 @Component
 public class MemberGenerator {
+
+    private static final String DEFAULT_INTEREST_AREA = InterestArea.SEONGBUK.getAreaName();
 
     private final MemberRepository memberRepository;
 
@@ -19,5 +22,9 @@ public class MemberGenerator {
 
     public Member generate(String socialId, String nickname) {
         return memberRepository.save(new Member(socialId, nickname));
+    }
+
+    public Member generateRegisteredMember(String socialId, String nickname, String phoneNumber) {
+        return memberRepository.save(new Member(socialId, nickname, phoneNumber, DEFAULT_INTEREST_AREA, true));
     }
 }

--- a/src/test/java/timeeat/service/service/MemberServiceTest.java
+++ b/src/test/java/timeeat/service/service/MemberServiceTest.java
@@ -1,6 +1,7 @@
 package timeeat.service.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -18,6 +19,76 @@ class MemberServiceTest extends BaseServiceTest {
 
     @Autowired
     private MemberService memberService;
+
+    @Nested
+    class ValidateNickname {
+
+        @Test
+        void 중복되지_않은_닉네임이면_예외가_발생하지_않는다() {
+            memberGenerator.generate("123", "nickname");
+            Member member = memberGenerator.generate("456", "unique-nickname");
+            String newNickname = "new-unique-nickname";
+
+            assertThatCode(() -> memberService.validateNickname(newNickname, member.getId()))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void 자신의_기존_닉네임이면_예외가_발생하지_않는다() {
+            Member member = memberGenerator.generate("123", "nickname");
+            String newNickname = "nickname";
+
+            assertThatCode(() -> memberService.validateNickname(newNickname, member.getId()))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void 중복된_닉네임이_있으면_예외가_발생한다() {
+            memberGenerator.generate("123", "duplicate-nickname");
+            Member member = memberGenerator.generate("456", "another-nickname");
+            String newNickname = "duplicate-nickname";
+
+            BusinessException exception = assertThrows(BusinessException.class,
+                    () -> memberService.validateNickname(newNickname, member.getId()));
+
+            assertThat(exception.getErrorCode()).isEqualTo(BusinessErrorCode.DUPLICATE_NICKNAME);
+        }
+    }
+
+    @Nested
+    class validatePhoneNumber {
+
+        @Test
+        void 중복되지_않은_전화번호이면_예외가_발생하지_않는다() {
+            memberGenerator.generate("123", "nickname");
+            Member member = memberGenerator.generate("456", "unique-nickname");
+            String newPhoneNumber = "01012345678";
+
+            assertThatCode(() -> memberService.validatePhoneNumber(newPhoneNumber, member.getId()))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void 자신의_기존_전화번호이면_예외가_발생하지_않는다() {
+            Member member = memberGenerator.generateRegisteredMember("123", "nickname", "01012345678");
+            String newPhoneNumber = "01012345678";
+
+            assertThatCode(() -> memberService.validatePhoneNumber(newPhoneNumber, member.getId()))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void 중복된_전화번호가_있으면_예외가_발생한다() {
+            memberGenerator.generateRegisteredMember("123", "nickname1", "01012345678");
+            Member member = memberGenerator.generateRegisteredMember("456", "nickname2", "01087654321");
+            String newPhoneNumber = "01012345678";
+
+            BusinessException exception = assertThrows(BusinessException.class,
+                    () -> memberService.validatePhoneNumber(newPhoneNumber, member.getId()));
+
+            assertThat(exception.getErrorCode()).isEqualTo(BusinessErrorCode.DUPLICATE_PHONE_NUMBER);
+        }
+    }
 
     @Nested
     class Update {
@@ -66,9 +137,7 @@ class MemberServiceTest extends BaseServiceTest {
         @Test
         void 중복된_전화번호가_있으면_예외가_발생한다() {
             String phoneNumber = "01012345678";
-            Member existMember = memberGenerator.generate("123", "nickname1");
-            memberService.update(existMember.getId(),
-                    new MemberUpdateRequest("nickname1", phoneNumber, "성북구", true));
+            memberGenerator.generateRegisteredMember("123", "nickname1", phoneNumber);
             Member updatedMember = memberGenerator.generate("456", "nickname2");
             MemberUpdateRequest request =
                     new MemberUpdateRequest("new-nickname", phoneNumber, "성북구", true);
@@ -82,9 +151,7 @@ class MemberServiceTest extends BaseServiceTest {
         @Test
         void 기존의_전화번호와_동일하면_정상적으로_회원_정보가_수정된다() {
             String phoneNumber = "01012345678";
-            Member member = memberGenerator.generate("123", "nickname1");
-            memberService.update(member.getId(),
-                    new MemberUpdateRequest("nickname1", phoneNumber, "성북구", true));
+            Member member = memberGenerator.generateRegisteredMember("123", "nickname1", phoneNumber);
             MemberUpdateRequest request =
                     new MemberUpdateRequest("new-nickname", phoneNumber, "성북구", true);
 

--- a/src/test/java/timeeat/service/service/MemberServiceTest.java
+++ b/src/test/java/timeeat/service/service/MemberServiceTest.java
@@ -56,7 +56,7 @@ class MemberServiceTest extends BaseServiceTest {
     }
 
     @Nested
-    class validatePhoneNumber {
+    class ValidatePhoneNumber {
 
         @Test
         void 중복되지_않은_전화번호이면_예외가_발생하지_않는다() {


### PR DESCRIPTION
## ✨ 개요
- 닉네임 중복 확인 API 구현
- 전화번호 중복 확인 API 구현

## 🧾 관련 이슈
closed #47 

## 🔍 참고 사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 닉네임 및 전화번호 중복 여부를 확인하는 API 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 필수 파라미터 누락 시 반환되는 오류 코드가 명확하게 구분되도록 개선되었습니다.

* **문서화**
  * 닉네임 및 전화번호 중복 확인 API에 대한 문서가 추가되었습니다.

* **테스트**
  * 닉네임과 전화번호 중복 확인 기능에 대한 단위 테스트 및 컨트롤러 테스트가 추가되었습니다.
  * 테스트 데이터 생성 방식이 일부 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->