### PR TITLE
[Fix] 요청한 클라이언트의 주소를 Origin 대신 Refer, Body 로 받도록 수정

### DIFF
--- a/src/main/java/timeeat/client/oauth/OauthClient.java
+++ b/src/main/java/timeeat/client/oauth/OauthClient.java
@@ -32,7 +32,7 @@ public class OauthClient {
 
         return UriComponentsBuilder.fromUriString("https://kauth.kakao.com/oauth/authorize")
                 .queryParam("client_id", properties.getClientId())
-                .queryParam("redirect_uri", origin + properties.getRedirectPath())
+                .queryParam("redirect_uri", createRedirectUri(origin))
                 .queryParam("response_type", "code")
                 .build()
                 .toUri();
@@ -44,7 +44,7 @@ public class OauthClient {
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("grant_type", "authorization_code");
         body.add("client_id", properties.getClientId());
-        body.add("redirect_uri", origin + properties.getRedirectPath());
+        body.add("redirect_uri", createRedirectUri(origin));
         body.add("code", code);
 
         return restClient.post()
@@ -59,6 +59,13 @@ public class OauthClient {
         if (!properties.isAllowedOrigin(origin)) {
             throw new BusinessException(BusinessErrorCode.UNAUTHORIZED_ORIGIN);
         }
+    }
+
+    private String createRedirectUri(String origin) {
+        return UriComponentsBuilder.fromUriString(origin)
+                .path(properties.getRedirectPath())
+                .build()
+                .toString();
     }
 
     public OauthMemberInformation requestMemberInformation(OauthToken token) {

--- a/src/main/java/timeeat/client/oauth/OauthProperties.java
+++ b/src/main/java/timeeat/client/oauth/OauthProperties.java
@@ -58,6 +58,11 @@ public class OauthProperties {
 
     public boolean isAllowedOrigin(String origin) {
         return allowedOrigins.stream()
-                .anyMatch(allowedOrigin -> origin.trim().startsWith(allowedOrigin));
+                .anyMatch(allowedOrigin -> isMatchedOrigin(allowedOrigin, origin));
+    }
+
+    private boolean isMatchedOrigin(String allowedOrigin, String origin) {
+        return origin.trim().equals(allowedOrigin)
+                || origin.trim().equals(allowedOrigin + "/");
     }
 }

--- a/src/main/java/timeeat/client/oauth/OauthProperties.java
+++ b/src/main/java/timeeat/client/oauth/OauthProperties.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.util.List;
 import lombok.Getter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import timeeat.exception.InitializeException;
 
 @Getter
 @ConfigurationProperties(prefix = "oauth")
@@ -25,22 +26,19 @@ public class OauthProperties {
 
     private void validateClientId(String clientId) {
         if (clientId == null || clientId.isBlank()) {
-            // TODO InitializeException 을 이용
-            throw new RuntimeException("Client ID must not be null or empty");
+            throw new InitializeException("Client ID must not be null or empty");
         }
     }
 
     private void validateRedirectPath(String redirectPath) {
         if (redirectPath == null || !redirectPath.startsWith("/")) {
-            // TODO InitializeException 을 이용
-            throw new RuntimeException("Redirect path must not be null or start with '/'");
+            throw new InitializeException("Redirect path must not be null or start with '/'");
         }
     }
 
     private void validateOrigins(List<String> origins) {
         if (origins == null || origins.isEmpty()) {
-            // TODO InitializeException 을 이용
-            throw new RuntimeException("Allowed origins must not be null or empty");
+            throw new InitializeException("Allowed origins must not be null or empty");
         }
         origins.forEach(this::validateOrigin);
     }
@@ -50,18 +48,16 @@ public class OauthProperties {
         try {
             uri = new URI(origin);
         } catch (Exception e) {
-            // TODO InitializeException 을 이용
-            throw new RuntimeException("Allowed origin must be a valid origin form: " + origin, e);
+            throw new InitializeException("Allowed origin must be a valid origin form: " + origin, e);
         }
 
         if (uri.getScheme() == null || uri.getHost() == null || !uri.getPath().isBlank()) {
-            // TODO InitializeException 을 이용
-            throw new RuntimeException("Allowed origin must be a valid origin form: " + origin);
+            throw new InitializeException("Allowed origin must be a valid origin form: " + origin);
         }
     }
 
     public boolean isAllowedOrigin(String origin) {
         return allowedOrigins.stream()
-                .anyMatch(allowedOrigin -> allowedOrigin.equalsIgnoreCase(origin.trim()));
+                .anyMatch(allowedOrigin -> origin.trim().startsWith(allowedOrigin));
     }
 }

--- a/src/main/java/timeeat/controller/auth/AuthController.java
+++ b/src/main/java/timeeat/controller/auth/AuthController.java
@@ -22,7 +22,7 @@ public class AuthController {
     private final AuthService authService;
 
     @GetMapping("/api/auth/login/oauth")
-    public ResponseEntity<Void> redirectOauthLoginPage(@RequestHeader(HttpHeaders.ORIGIN) String origin) {
+    public ResponseEntity<Void> redirectOauthLoginPage(@RequestHeader(HttpHeaders.REFERER) String origin) {
         URI oauthLoginUrl = authService.getOauthLoginUrl(origin);
 
         return ResponseEntity
@@ -33,9 +33,8 @@ public class AuthController {
 
     // TODO : login() ControllerTest, DocumentTest 수정
     @PostMapping("/api/auth/login")
-    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request,
-                                               @RequestHeader(HttpHeaders.ORIGIN) String origin) {
-        MemberResponse member = authService.login(request, origin);
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
+        MemberResponse member = authService.login(request);
         TokenResponse token = new TokenResponse(
                 jwtManager.issueAccessToken(member.id()),
                 jwtManager.issueRefreshToken(member.id()));

--- a/src/main/java/timeeat/controller/auth/LoginRequest.java
+++ b/src/main/java/timeeat/controller/auth/LoginRequest.java
@@ -1,4 +1,4 @@
 package timeeat.controller.auth;
 
-public record LoginRequest(String code) {
+public record LoginRequest(String code, String origin) {
 }

--- a/src/main/java/timeeat/exception/InitializeException.java
+++ b/src/main/java/timeeat/exception/InitializeException.java
@@ -5,4 +5,8 @@ public class InitializeException extends RuntimeException {
     public InitializeException(String message) {
         super(message);
     }
+
+    public InitializeException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/src/main/java/timeeat/service/auth/AuthService.java
+++ b/src/main/java/timeeat/service/auth/AuthService.java
@@ -27,8 +27,8 @@ public class AuthService {
     }
 
     @Transactional
-    public MemberResponse login(LoginRequest request, String origin) {
-        OauthToken oauthToken = oauthClient.requestOauthToken(request.code(), origin);
+    public MemberResponse login(LoginRequest request) {
+        OauthToken oauthToken = oauthClient.requestOauthToken(request.code(), request.origin());
         OauthMemberInformation oauthInformation = oauthClient.requestMemberInformation(oauthToken);
 
         Optional<Member> optionalMember = memberRepository.findBySocialId(Long.toString(oauthInformation.socialId()));

--- a/src/test/java/timeeat/client/oauth/OauthClientTest.java
+++ b/src/test/java/timeeat/client/oauth/OauthClientTest.java
@@ -49,8 +49,8 @@ class OauthClientTest {
             assertAll(
                     () -> assertThat(uri.getHost()).isEqualTo("kauth.kakao.com"),
                     () -> assertThat(uri.getPath()).isEqualTo("/oauth/authorize"),
-                    () -> assertThat(uri.getQuery()).contains("client_id=%s".formatted(properties.getClientId())),
-                    () -> assertThat(uri.getQuery()).contains("redirect_uri=%s".formatted(redirectUri)),
+                    () -> assertThat(uri.getQuery()).contains("client_id=%s&".formatted(properties.getClientId())),
+                    () -> assertThat(uri.getQuery()).contains("redirect_uri=%s&".formatted(redirectUri)),
                     () -> assertThat(uri.getQuery()).contains("response_type=code")
             );
         }
@@ -63,6 +63,16 @@ class OauthClientTest {
                     () -> oauthClient.getOauthLoginUrl(origin));
 
             assertThat(exception.getErrorCode()).isEqualTo(BusinessErrorCode.UNAUTHORIZED_ORIGIN);
+        }
+
+        @Test
+        void origin_뒤에_슬래시가_붙어도_정상적으로_처리된다() {
+            String origin = properties.getAllowedOrigins().getFirst();
+            String redirectUri = origin + properties.getRedirectPath();
+
+            URI uri = oauthClient.getOauthLoginUrl(origin + "/");
+
+            assertThat(uri.getQuery()).contains("redirect_uri=%s&".formatted(redirectUri));
         }
     }
 

--- a/src/test/java/timeeat/client/oauth/OauthPropertiesTest.java
+++ b/src/test/java/timeeat/client/oauth/OauthPropertiesTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import java.util.List;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -56,7 +55,8 @@ class OauthPropertiesTest {
             assertThat(isAllowed).isTrue();
         }
 
-        @Test
+        @ParameterizedTest
+        @ValueSource(strings = {"https://not-allowed.com", "http://localhost:8080/path", "http://localhost:8080nono"})
         void 허용되지_않은_오리진인_경우_false를_반환한다() {
             OauthProperties oauthProperties = new OauthProperties("client-id", "/path",
                     List.of("http://localhost:8080"));

--- a/src/test/java/timeeat/client/oauth/OauthPropertiesTest.java
+++ b/src/test/java/timeeat/client/oauth/OauthPropertiesTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import timeeat.exception.InitializeException;
 
 class OauthPropertiesTest {
 
@@ -19,7 +20,7 @@ class OauthPropertiesTest {
         @NullAndEmptySource
         void 클라이언트_아이디가_비어있는_경우_예외를_던진다(String clientId) {
             assertThatThrownBy(() -> new OauthProperties(clientId, "/path", List.of("http://localhost:8080")))
-                    .isInstanceOf(RuntimeException.class)
+                    .isInstanceOf(InitializeException.class)
                     .hasMessage("Client ID must not be null or empty");
         }
 
@@ -27,7 +28,7 @@ class OauthPropertiesTest {
         @ValueSource(strings = {"path", ".path", "path/", ""})
         void 리다이렉트_경로가_경로_형식이_아닌_경우_예외를_던진다(String redirectPath) {
             assertThatThrownBy(() -> new OauthProperties("client-id", redirectPath, List.of("http://localhost:8080")))
-                    .isInstanceOf(RuntimeException.class)
+                    .isInstanceOf(InitializeException.class)
                     .hasMessage("Redirect path must not be null or start with '/'");
         }
 
@@ -35,7 +36,7 @@ class OauthPropertiesTest {
         @ValueSource(strings = {"invalid-url", "http://", "http://:8080", "http://localhost:8080/path", " "})
         void 허용된_오리진이_유효하지_않은_URL인_경우_예외를_던진다(String origin) {
             assertThatThrownBy(() -> new OauthProperties("client-id", "/path", List.of(origin)))
-                    .isInstanceOf(RuntimeException.class)
+                    .isInstanceOf(InitializeException.class)
                     .hasMessageContaining("Allowed origin must be a valid origin form");
         }
     }
@@ -44,7 +45,8 @@ class OauthPropertiesTest {
     class IsAllowedOrigin {
 
         @ParameterizedTest
-        @ValueSource(strings = {"http://localhost:8080", " http://localhost:8080 ", "https://example.com"})
+        @ValueSource(strings = {"http://localhost:8080", " http://localhost:8080 ",
+                "https://example.com", "https://example.com/"})
         void 허용된_오리진인_경우_true를_반환한다(String allowedOrigin) {
             List<String> origins = List.of("http://localhost:8080", "https://example.com");
             OauthProperties oauthProperties = new OauthProperties("client-id", "/path", origins);

--- a/src/test/java/timeeat/controller/auth/AuthControllerTest.java
+++ b/src/test/java/timeeat/controller/auth/AuthControllerTest.java
@@ -12,12 +12,6 @@ import timeeat.controller.BaseControllerTest;
 
 class AuthControllerTest extends BaseControllerTest {
 
-    @Value("${oauth.client-id}")
-    private String clientId;
-
-    @Value("${oauth.redirect-path}")
-    private String redirectPath;
-
     @Value("${oauth.allowed-origins[0]}")
     private String allowedOrigin;
 
@@ -26,11 +20,8 @@ class AuthControllerTest extends BaseControllerTest {
 
         @Test
         void Oauth_로그인_페이지로_리다이렉트_할_수_있다() {
-            String origin = allowedOrigin;
-            String expectedRedirectPath = origin + redirectPath;
-
             String location = given()
-                    .header(HttpHeaders.ORIGIN, origin)
+                    .header(HttpHeaders.REFERER, allowedOrigin)
                     .redirects().follow(false)
                     .when()
                     .get("/api/auth/login/oauth")
@@ -47,10 +38,9 @@ class AuthControllerTest extends BaseControllerTest {
 
         @Test
         void 인가코드를_통해_로그인할_수_있다() {
-            LoginRequest request = new LoginRequest("auth-code");
+            LoginRequest request = new LoginRequest("auth-code", allowedOrigin);
 
             LoginResponse response = given().body(request)
-                    .header(HttpHeaders.ORIGIN, allowedOrigin)
                     .contentType(ContentType.JSON)
                     .when().post("/api/auth/login")
                     .then()

--- a/src/test/java/timeeat/document/auth/AuthDocumentTest.java
+++ b/src/test/java/timeeat/document/auth/AuthDocumentTest.java
@@ -1,7 +1,6 @@
 package timeeat.document.auth;
 
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
@@ -37,7 +36,7 @@ public class AuthDocumentTest extends BaseDocumentTest {
                 .tag(Tag.AUTH_API)
                 .summary("OAuth 로그인 페이지 리다이렉트")
                 .requestHeader(
-                        headerWithName(HttpHeaders.ORIGIN).description("요청 Origin")
+                        headerWithName(HttpHeaders.REFERER).description("요청 Origin")
                 );
 
         RestDocsResponse responseDocument = response()
@@ -56,7 +55,7 @@ public class AuthDocumentTest extends BaseDocumentTest {
 
             given(document)
                     .redirects().follow(false)
-                    .header(HttpHeaders.ORIGIN, origin)
+                    .header(HttpHeaders.REFERER, origin)
                     .when()
                     .get("/api/auth/login/oauth")
                     .then()
@@ -71,7 +70,8 @@ public class AuthDocumentTest extends BaseDocumentTest {
                 .tag(Tag.AUTH_API)
                 .summary("로그인")
                 .requestBodyField(
-                        fieldWithPath("code").type(STRING).description("Oauth 인가 코드")
+                        fieldWithPath("code").type(STRING).description("Oauth 인가 코드"),
+                        fieldWithPath("origin").type(STRING).description("요청 Origin")
                 );
 
         RestDocsResponse responseDocument = response()
@@ -90,9 +90,9 @@ public class AuthDocumentTest extends BaseDocumentTest {
 
         @Test
         void 로그인_성공() {
-            LoginRequest request = new LoginRequest("code");
+            LoginRequest request = new LoginRequest("code", "http://localhost:3000");
             MemberResponse response = new MemberResponse(1L, true, "닉네임", null, null, null);
-            doReturn(response).when(authService).login(eq(request), anyString());
+            doReturn(response).when(authService).login(request);
 
             var document = document("auth/login", 201)
                     .request(requestDocument)
@@ -101,7 +101,6 @@ public class AuthDocumentTest extends BaseDocumentTest {
 
             given(document)
                     .contentType(ContentType.JSON)
-                    .header(HttpHeaders.ORIGIN, origin)
                     .body(request)
                     .when().post("/api/auth/login")
                     .then().statusCode(201);

--- a/src/test/java/timeeat/service/auth/AuthServiceTest.java
+++ b/src/test/java/timeeat/service/auth/AuthServiceTest.java
@@ -20,9 +20,9 @@ class AuthServiceTest extends BaseServiceTest {
 
         @Test
         void 로그인_최초_요청_시_회원가입_및_로그인_처리를_한다() {
-            LoginRequest request = new LoginRequest("auth_code");
+            LoginRequest request = new LoginRequest("auth_code", "http://localhost:3000");
 
-            MemberResponse response = authService.login(request, "http://localhost:8080");
+            MemberResponse response = authService.login(request);
 
             assertAll(
                     () -> assertThat(response.isSignUp()).isTrue(),
@@ -36,9 +36,9 @@ class AuthServiceTest extends BaseServiceTest {
         @Test
         void 로그인_최초_요청이_아닐_경우_로그인만_처리를_한다() {
             memberGenerator.generate("123");
-            LoginRequest request = new LoginRequest("auth_code");
+            LoginRequest request = new LoginRequest("auth_code", "http://localhost:3000");
 
-            MemberResponse response = authService.login(request, "http://localhost:8080");
+            MemberResponse response = authService.login(request);
 
             assertThat(response.isSignUp()).isFalse();
         }


### PR DESCRIPTION
## ✨ 개요
- 현재 Client의 주소를 Origin을 통해 받고 있음
- `OAuth 로그인 페이지 리다이렉트 API` 에서는 Referer 헤더를 통해 `http://localhost:3000/` 형식으로 받도록 수정
    - Client Library 에서 사용하는 기본 값
- `로그인 API` 에서는 Request body의 `origin` 필드를 통해 `http://localhost:3000` 형식으로 받도록 수정
    - Next.js 를 이용하는 요청이므로 body 값으로 전달

## 🧾 관련 이슈
closed #49 

## 🔍 참고 사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * OAuth 로그인 및 토큰 요청 시 리디렉션 URI 생성 방식이 개선되어, 슬래시 등 경계 상황에서도 올바르게 동작합니다.
  * 허용된 Origin 판별 로직이 개선되어, Origin에 슬래시가 포함되어도 정상적으로 처리됩니다.

* **신규 기능**
  * 로그인 요청 시 origin 정보가 추가로 전달됩니다.

* **리팩터**
  * 예외 처리 방식이 개선되어, 초기화 오류 시 더 구체적인 예외가 발생합니다.
  * 로그인 관련 API에서 Origin 헤더 사용이 제거되고, 내부 파라미터 전달 방식이 간소화되었습니다.

* **테스트**
  * 리디렉션 URI, Origin 처리, 예외 처리 등 변경된 로직에 대한 테스트가 보강되었습니다.
  * 문서화 테스트 및 컨트롤러 테스트가 최신 로직에 맞게 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->