### PR TITLE
[Docs] 에러 응답에 대한 문서화

### DIFF
--- a/src/test/java/eatda/document/BaseDocumentTest.java
+++ b/src/test/java/eatda/document/BaseDocumentTest.java
@@ -1,6 +1,11 @@
 package eatda.document;
 
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+
 import eatda.controller.web.jwt.JwtManager;
+import eatda.exception.BusinessErrorCode;
 import eatda.service.auth.AuthService;
 import eatda.service.service.MemberService;
 import io.restassured.RestAssured;
@@ -9,7 +14,6 @@ import io.restassured.specification.RequestSpecification;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.restdocs.RestDocumentationContextProvider;
@@ -23,12 +27,20 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public abstract class BaseDocumentTest {
 
+    protected static final RestDocsResponse ERROR_RESPONSE = new RestDocsResponse()
+            .responseBodyField(
+                    fieldWithPath("errorCode").type(STRING).description("에러 코드"),
+                    fieldWithPath("message").type(STRING).description("에러 메시지")
+            );
+    private static final String MOCKED_ACCESS_TOKEN = "access-token";
+    private static final String MOCKED_REFRESH_TOKEN = "refresh-token";
+
     @MockitoBean
     protected AuthService authService;
     @MockitoBean
     protected MemberService memberService;
-    @Autowired
-    private JwtManager jwtManager;
+    @MockitoBean
+    protected JwtManager jwtManager;
     @LocalServerPort
     private int port;
 
@@ -44,6 +56,14 @@ public abstract class BaseDocumentTest {
                 .build();
     }
 
+    @BeforeEach
+    void mockingJwtManager() {
+        doReturn(MOCKED_ACCESS_TOKEN).when(jwtManager).issueAccessToken(1L);
+        doReturn(MOCKED_REFRESH_TOKEN).when(jwtManager).issueRefreshToken(1L);
+        doReturn(1L).when(jwtManager).resolveAccessToken(MOCKED_ACCESS_TOKEN);
+        doReturn(1L).when(jwtManager).resolveRefreshToken(MOCKED_REFRESH_TOKEN);
+    }
+
     protected final RestDocsRequest request() {
         return new RestDocsRequest();
     }
@@ -56,16 +76,20 @@ public abstract class BaseDocumentTest {
         return new RestDocsFilterBuilder(identifierPrefix, Integer.toString(statusCode));
     }
 
+    protected final RestDocsFilterBuilder document(String identifierPrefix, BusinessErrorCode errorCode) {
+        return new RestDocsFilterBuilder(identifierPrefix, errorCode.name());
+    }
+
     protected final RequestSpecification given(RestDocumentationFilter documentationFilter) {
         return RestAssured.given(spec)
                 .filter(documentationFilter);
     }
 
     protected final String accessToken() {
-        return jwtManager.issueAccessToken(1L);
+        return MOCKED_ACCESS_TOKEN;
     }
 
     protected final String refreshToken() {
-        return jwtManager.issueRefreshToken(1L);
+        return MOCKED_REFRESH_TOKEN;
     }
 }

--- a/src/test/java/eatda/document/member/MemberDocumentTest.java
+++ b/src/test/java/eatda/document/member/MemberDocumentTest.java
@@ -43,7 +43,7 @@ public class MemberDocumentTest extends BaseDocumentTest {
                 );
 
         @Test
-        void 중복되지_않는_닉네임을_확인할_수_있다() {
+        void 중복_닉네임_확인_성공() {
             doNothing().when(memberService).validateNickname(anyString(), anyLong());
 
             var document = document("member/nickname-check", 204)
@@ -61,11 +61,11 @@ public class MemberDocumentTest extends BaseDocumentTest {
         @EnumSource(value = BusinessErrorCode.class,
                 names = {"UNAUTHORIZED_MEMBER", "EXPIRED_TOKEN", "DUPLICATE_NICKNAME"})
         @ParameterizedTest
-        void 중복된_닉네임을_확인할_수_있다(BusinessErrorCode errorCode) {
+        void 중복_닉네임_확인_실패(BusinessErrorCode errorCode) {
             doThrow(new BusinessException(errorCode))
                     .when(memberService).validateNickname(anyString(), anyLong());
 
-            var document = document("member/nickname-check", 409)
+            var document = document("member/nickname-check", errorCode)
                     .request(requestDocument)
                     .response(ERROR_RESPONSE)
                     .build();
@@ -92,7 +92,7 @@ public class MemberDocumentTest extends BaseDocumentTest {
                 );
 
         @Test
-        void 중복되지_않는_전화번호를_확인할_수_있다() {
+        void 중복_전화번호_확인_성공() {
             doNothing().when(memberService).validatePhoneNumber(anyString(), anyLong());
 
             var document = document("member/phone-number-check", 204)
@@ -110,11 +110,11 @@ public class MemberDocumentTest extends BaseDocumentTest {
         @EnumSource(value = BusinessErrorCode.class,
                 names = {"UNAUTHORIZED_MEMBER", "EXPIRED_TOKEN", "DUPLICATE_PHONE_NUMBER"})
         @ParameterizedTest
-        void 중복된_전화번호를_확인할_수_있다(BusinessErrorCode errorCode) {
+        void 중복_전화번호_확인_실패(BusinessErrorCode errorCode) {
             doThrow(new BusinessException(errorCode))
                     .when(memberService).validatePhoneNumber(anyString(), anyLong());
 
-            var document = document("member/phone-number-check", 409)
+            var document = document("member/phone-number-check", errorCode)
                     .request(requestDocument)
                     .response(ERROR_RESPONSE)
                     .build();
@@ -180,7 +180,7 @@ public class MemberDocumentTest extends BaseDocumentTest {
             MemberUpdateRequest request = new MemberUpdateRequest("update-nickname", "01012345678", "성북구", true);
             doThrow(new BusinessException(errorCode)).when(memberService).update(anyLong(), eq(request));
 
-            var document = document("member/update", errorCode.getStatus().value())
+            var document = document("member/update", errorCode)
                     .request(requestDocument)
                     .response(ERROR_RESPONSE)
                     .build();

--- a/src/test/java/eatda/document/member/MemberDocumentTest.java
+++ b/src/test/java/eatda/document/member/MemberDocumentTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
@@ -18,9 +19,13 @@ import eatda.document.BaseDocumentTest;
 import eatda.document.RestDocsRequest;
 import eatda.document.RestDocsResponse;
 import eatda.document.Tag;
+import eatda.exception.BusinessErrorCode;
+import eatda.exception.BusinessException;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.http.HttpHeaders;
 
 public class MemberDocumentTest extends BaseDocumentTest {
@@ -52,6 +57,26 @@ public class MemberDocumentTest extends BaseDocumentTest {
                     .when().get("/api/member/nickname/check")
                     .then().statusCode(204);
         }
+
+        @EnumSource(value = BusinessErrorCode.class,
+                names = {"UNAUTHORIZED_MEMBER", "EXPIRED_TOKEN", "DUPLICATE_NICKNAME"})
+        @ParameterizedTest
+        void 중복된_닉네임을_확인할_수_있다(BusinessErrorCode errorCode) {
+            doThrow(new BusinessException(errorCode))
+                    .when(memberService).validateNickname(anyString(), anyLong());
+
+            var document = document("member/nickname-check", 409)
+                    .request(requestDocument)
+                    .response(ERROR_RESPONSE)
+                    .build();
+
+            given(document)
+                    .contentType(ContentType.JSON)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken())
+                    .queryParam("nickname", "existing-nickname")
+                    .when().get("/api/member/nickname/check")
+                    .then().statusCode(errorCode.getStatus().value());
+        }
     }
 
     @Nested
@@ -80,6 +105,26 @@ public class MemberDocumentTest extends BaseDocumentTest {
                     .queryParam("phoneNumber", "01098765432")
                     .when().get("/api/member/phone-number/check")
                     .then().statusCode(204);
+        }
+
+        @EnumSource(value = BusinessErrorCode.class,
+                names = {"UNAUTHORIZED_MEMBER", "EXPIRED_TOKEN", "DUPLICATE_PHONE_NUMBER"})
+        @ParameterizedTest
+        void 중복된_전화번호를_확인할_수_있다(BusinessErrorCode errorCode) {
+            doThrow(new BusinessException(errorCode))
+                    .when(memberService).validatePhoneNumber(anyString(), anyLong());
+
+            var document = document("member/phone-number-check", 409)
+                    .request(requestDocument)
+                    .response(ERROR_RESPONSE)
+                    .build();
+
+            given(document)
+                    .contentType(ContentType.JSON)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken())
+                    .queryParam("phoneNumber", "01012345678")
+                    .when().get("/api/member/phone-number/check")
+                    .then().statusCode(errorCode.getStatus().value());
         }
     }
 
@@ -125,6 +170,27 @@ public class MemberDocumentTest extends BaseDocumentTest {
                     .body(request)
                     .when().put("/api/member")
                     .then().statusCode(200);
+        }
+
+        @EnumSource(value = BusinessErrorCode.class,
+                names = {"UNAUTHORIZED_MEMBER", "EXPIRED_TOKEN", "DUPLICATE_NICKNAME", "DUPLICATE_PHONE_NUMBER",
+                        "INVALID_MOBILE_PHONE_NUMBER", "INVALID_MARKETING_CONSENT"})
+        @ParameterizedTest
+        void 회원_정보_수정_실패(BusinessErrorCode errorCode) {
+            MemberUpdateRequest request = new MemberUpdateRequest("update-nickname", "01012345678", "성북구", true);
+            doThrow(new BusinessException(errorCode)).when(memberService).update(anyLong(), eq(request));
+
+            var document = document("member/update", errorCode.getStatus().value())
+                    .request(requestDocument)
+                    .response(ERROR_RESPONSE)
+                    .build();
+
+            given(document)
+                    .contentType(ContentType.JSON)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken())
+                    .body(request)
+                    .when().put("/api/member")
+                    .then().statusCode(errorCode.getStatus().value());
         }
     }
 }

--- a/src/test/java/eatda/document/store/StoreDocumentTest.java
+++ b/src/test/java/eatda/document/store/StoreDocumentTest.java
@@ -77,7 +77,7 @@ public class StoreDocumentTest extends BaseDocumentTest {
             String query = "농민백암순대";
             doThrow(new BusinessException(errorCode)).when(storeService).searchStores(anyString());
 
-            var document = document("store/search", 404)
+            var document = document("store/search", errorCode)
                     .request(requestDocument)
                     .response(ERROR_RESPONSE)
                     .build();


### PR DESCRIPTION
## ✨ 개요
#### As-Is
- 현재 Swagger 문서에는 정상 응답만 보여줌
- 특정 API에 어떤 에러가 발생할지 알 수 없음

#### To-Be
- 구현된 API 에 에러 응답 문서화 실시

## 🧾 관련 이슈
closed #61 

## 🔍 참고 사항 (선택)
- 기존에는 DocumentTest 상황에서 JwtManager를 실 객체로 사용했는데, 특정 API에서 mocking이 필요하여 BaseDocumentTest에서 `@MockitoBean`을 이용한 mocking 진행했습니다.
- 추후 merge 과정에서 맛집 조회 API(#60)에도 에러 코드 추가 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **테스트**
  * 인증, 회원, 음식점 검색 API의 실패 시나리오에 대한 파라미터화된 테스트가 추가되어 다양한 에러 코드에 대한 응답을 검증합니다.
  * 토큰 및 예외 응답에 대한 모킹이 개선되어 테스트의 일관성과 유지보수가 향상되었습니다.
  * API 문서화 테스트가 실패 케이스까지 확장되어 에러 응답 문서가 보강되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->