### PR TITLE
[Fix] 회원가입 API 에서 이메일을 이용하도록 수정

### DIFF
--- a/src/main/java/eatda/client/oauth/OauthMemberInformation.java
+++ b/src/main/java/eatda/client/oauth/OauthMemberInformation.java
@@ -9,7 +9,7 @@ import eatda.domain.member.Member;
 public record OauthMemberInformation(long socialId, String email, String nickname) {
 
     public Member toMember() {
-        return new Member(Long.toString(socialId), nickname);
+        return new Member(Long.toString(socialId), email, nickname);
     }
 }
 

--- a/src/main/java/eatda/client/oauth/OauthMemberInformation.java
+++ b/src/main/java/eatda/client/oauth/OauthMemberInformation.java
@@ -6,7 +6,7 @@ import eatda.domain.member.Member;
 
 @JsonDeserialize(using = OauthMemberInformationDeserializer.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record OauthMemberInformation(long socialId, String nickname) {
+public record OauthMemberInformation(long socialId, String email, String nickname) {
 
     public Member toMember() {
         return new Member(Long.toString(socialId), nickname);

--- a/src/main/java/eatda/client/oauth/OauthMemberInformationDeserializer.java
+++ b/src/main/java/eatda/client/oauth/OauthMemberInformationDeserializer.java
@@ -14,11 +14,15 @@ public class OauthMemberInformationDeserializer extends JsonDeserializer<OauthMe
         JsonNode root = jsonParser.getCodec().readTree(jsonParser);
 
         long id = root.path("id").asLong();
+        String email = root
+                .path("kakao_account")
+                .path("email")
+                .asText(null);
         String nickname = root
                 .path("kakao_account")
                 .path("profile")
                 .path("nickname")
                 .asText(null);
-        return new OauthMemberInformation(id, nickname);
+        return new OauthMemberInformation(id, email, nickname);
     }
 }

--- a/src/main/java/eatda/controller/member/MemberResponse.java
+++ b/src/main/java/eatda/controller/member/MemberResponse.java
@@ -3,6 +3,7 @@ package eatda.controller.member;
 import eatda.domain.member.Member;
 
 public record MemberResponse(long id,
+                             String email,
                              boolean isSignUp,
                              String nickname,
                              String phoneNumber,
@@ -11,6 +12,7 @@ public record MemberResponse(long id,
 
     public MemberResponse(Member member, boolean isSignUp) {
         this(member.getId(),
+                member.getEmail(),
                 isSignUp,
                 member.getNickname(),
                 member.getPhoneNumber(),

--- a/src/main/java/eatda/domain/member/Member.java
+++ b/src/main/java/eatda/domain/member/Member.java
@@ -20,7 +20,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 
-    private static final String EMAIL_REGEX = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$";
+    private static final String EMAIL_REGEX = "^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/eatda/domain/member/Member.java
+++ b/src/main/java/eatda/domain/member/Member.java
@@ -20,12 +20,17 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 
+    private static final String EMAIL_REGEX = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(name = "social_id", unique = true, nullable = false)
     private String socialId;
+
+    @Column(name = "email", unique = true, nullable = false)
+    private String email;
 
     @Column(name = "nickname")
     private String nickname;
@@ -36,19 +41,22 @@ public class Member {
     @Column(name = "opt_in_marketing")
     private Boolean optInMarketing;
 
-    public Member(String socialId, String nickname) {
+    public Member(String socialId, String email, String nickname) {
         validateSocialId(socialId);
+        validateEmail(email);
         this.socialId = socialId;
+        this.email = email;
         this.nickname = nickname;
     }
 
     public Member(
             String socialId,
+            String email,
             String nickname,
             String mobilePhoneNumber,
             Boolean optInMarketing
     ) {
-        this(socialId, nickname);
+        this(socialId, email, nickname);
         validateOptInMarketing(optInMarketing);
         this.mobilePhoneNumber = new MobilePhoneNumber(mobilePhoneNumber);
         this.optInMarketing = optInMarketing;
@@ -64,6 +72,12 @@ public class Member {
     private void validateSocialId(String socialId) {
         if (socialId == null || socialId.trim().isEmpty()) {
             throw new BusinessException(BusinessErrorCode.INVALID_SOCIAL_ID);
+        }
+    }
+
+    private void validateEmail(String email) {
+        if (email == null || !email.matches(EMAIL_REGEX)) {
+            throw new BusinessException(BusinessErrorCode.INVALID_EMAIL);
         }
     }
 

--- a/src/main/java/eatda/exception/BusinessErrorCode.java
+++ b/src/main/java/eatda/exception/BusinessErrorCode.java
@@ -14,6 +14,8 @@ public enum BusinessErrorCode {
     INVALID_SOCIAL_ID("MEM005", "소셜 ID는 필수입니다."),
     DUPLICATE_NICKNAME("MEM006", "이미 사용 중인 닉네임입니다."),
     DUPLICATE_PHONE_NUMBER("MEM007", "이미 사용 중인 전화번호입니다."),
+    INVALID_EMAIL("MEM008", "유효하지 않은 이메일 형식입니다."),
+
 
     // Store
     INVALID_STORE_CATEGORY("STO001", "유효하지 않은 매장 카테고리입니다."),
@@ -54,7 +56,8 @@ public enum BusinessErrorCode {
     INVALID_IMAGE_TYPE("CLIENT010", "지원하지 않는 이미지 형식입니다.", HttpStatus.BAD_REQUEST),
     FILE_UPLOAD_FAILED("SERVER002", "파일 업로드에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     FILE_URL_GENERATION_FAILED("SERVER003", "파일 URL 생성에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    PRESIGNED_URL_GENERATION_FAILED("SERVER004", "Presigned URL 생성에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    PRESIGNED_URL_GENERATION_FAILED("SERVER004", "Presigned URL 생성에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    ;
 
     private final String code;
     private final String message;

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -18,6 +18,7 @@ CREATE TABLE `store`
 CREATE TABLE `member`
 (
     `id`               BIGINT       NOT NULL AUTO_INCREMENT,
+    `email`            VARCHAR(255) NOT NULL,
     `social_id`        VARCHAR(255) NOT NULL,
     `nickname`         VARCHAR(255) NULL,
     `phone_number`     VARCHAR(255) NULL COMMENT '(`-` 없이))',

--- a/src/main/resources/db/seed/dev/V2__dev_init_data.sql
+++ b/src/main/resources/db/seed/dev/V2__dev_init_data.sql
@@ -1,11 +1,11 @@
-INSERT INTO member (id, social_id, nickname, phone_number, opt_in_marketing)
-VALUES (1, 123456789, '이승로', '01012345678', true),
-       (2, 987654321, '이충안', '01087654321', false),
-       (3, 456789123, '장수빈', '01045678912', true),
-       (4, 789123456, '서준환', '01078912345', true),
-       (5, 321251287, '신민선', '01034574568', false),
-       (6, 324569987, '박희수', '01043609998', false),
-       (7, 323487985, '하아얀', '01065083298', false);
+INSERT INTO member (id, social_id, email, nickname, phone_number, opt_in_marketing)
+VALUES (1, 123456789, 'default1@kakao.com', '이승로', '01012345678', true),
+       (2, 987654321, 'default2@kakao.com', '이충안', '01087654321', false),
+       (3, 456789123, 'default3@kakao.com', '장수빈', '01045678912', true),
+       (4, 789123456, 'default4@kakao.com', '서준환', '01078912345', true),
+       (5, 321251287, 'default5@kakao.com', '신민선', '01034574568', false),
+       (6, 324569987, 'default6@kakao.com', '박희수', '01043609998', false),
+       (7, 323487985, 'default7@kakao.com', '하아얀', '01065083298', false);
 
 INSERT INTO store (id, name, category, latitude, longitude,
                    address, phone_number, image_url, open_time, close_time,

--- a/src/main/resources/db/seed/local/V2__local_init_data.sql
+++ b/src/main/resources/db/seed/local/V2__local_init_data.sql
@@ -1,10 +1,10 @@
-INSERT INTO member (id, social_id, nickname, phone_number, opt_in_marketing)
-VALUES (1, 123456789, '이승로', '01012345678', true),
-       (3, 456789123, '장수빈', '01045678912', true),
-       (4, 789123456, '서준환', '01078912345', true),
-       (5, 321251287, '신민선', '01034574568', false),
-       (6, 324569987, '박희수', '01043609998', false),
-       (7, 323487985, '하아얀', '01065083298', false);
+INSERT INTO member (id, social_id, email, nickname, phone_number, opt_in_marketing)
+VALUES (1, 123456789, 'default1@email.com', '이승로', '01012345678', true),
+       (3, 456789123, 'default3@email.com', '장수빈', '01045678912', true),
+       (4, 789123456, 'default4@email.com', '서준환', '01078912345', true),
+       (5, 321251287, 'default5@email.com', '신민선', '01034574568', false),
+       (6, 324569987, 'default6@email.com', '박희수', '01043609998', false),
+       (7, 323487985, 'default7@email.com', '하아얀', '01065083298', false);
 
 INSERT INTO store (id, name, category, latitude, longitude,
                    address, phone_number, image_url, open_time, close_time,

--- a/src/test/java/eatda/client/oauth/OauthClientTest.java
+++ b/src/test/java/eatda/client/oauth/OauthClientTest.java
@@ -117,15 +117,22 @@ class OauthClientTest {
         void Oauth_회원정보를_요청할_수_있다() {
             setMockServer(HttpMethod.GET, "https://kapi.kakao.com/v2/user/me", """
                     {
-                        "id":123456789,
-                        "connected_at": "2022-04-11T01:45:28Z",
+                        "id": 123456789,
+                        "connected_at": "2025-07-08T13:31:28Z",
+                        "properties": {
+                            "nickname": "이충안"
+                        },
                         "kakao_account": {
                             "profile_nickname_needs_agreement": false,
-                            "profile_image_needs_agreement": false,
                             "profile": {
-                                "nickname": "홍길동",
+                                "nickname": "이충안",
                                 "is_default_nickname": false
-                            }
+                            },
+                            "has_email": true,
+                            "email_needs_agreement": false,
+                            "is_email_valid": true,
+                            "is_email_verified": true,
+                            "email": "cnddkscndgus@naver.com"
                         }
                     }""");
             OauthToken token = new OauthToken("test-access-token");
@@ -134,7 +141,8 @@ class OauthClientTest {
 
             assertAll(
                     () -> assertThat(memberInfo.socialId()).isEqualTo(123456789L),
-                    () -> assertThat(memberInfo.nickname()).isEqualTo("홍길동")
+                    () -> assertThat(memberInfo.email()).isEqualTo("cnddkscndgus@naver.com"),
+                    () -> assertThat(memberInfo.nickname()).isEqualTo("이충안")
             );
         }
     }

--- a/src/test/java/eatda/controller/BaseControllerTest.java
+++ b/src/test/java/eatda/controller/BaseControllerTest.java
@@ -37,7 +37,7 @@ public class BaseControllerTest {
 
     private static final OauthToken DEFAULT_OAUTH_TOKEN = new OauthToken("oauth-access-token");
     private static final OauthMemberInformation DEFAULT_OAUTH_MEMBER_INFO =
-            new OauthMemberInformation(314159248183772L, "nickname");
+            new OauthMemberInformation(314159248183772L, "constant@kakao.com", "nickname");
 
     @Autowired
     protected MemberGenerator memberGenerator;

--- a/src/test/java/eatda/controller/BaseControllerTest.java
+++ b/src/test/java/eatda/controller/BaseControllerTest.java
@@ -87,12 +87,14 @@ public class BaseControllerTest {
     }
 
     protected final String accessToken() {
-        Member member = memberGenerator.generate(Long.toString(DEFAULT_OAUTH_MEMBER_INFO.socialId()));
+        Member member = memberGenerator.generateByEmail(Long.toString(DEFAULT_OAUTH_MEMBER_INFO.socialId()),
+                "authAccessToken@example.com");
         return jwtManager.issueAccessToken(member.getId());
     }
 
     protected final String refreshToken() {
-        Member member = memberGenerator.generate(Long.toString(DEFAULT_OAUTH_MEMBER_INFO.socialId()));
+        Member member = memberGenerator.generateByEmail(Long.toString(DEFAULT_OAUTH_MEMBER_INFO.socialId()),
+                "authRefreshToken@example.com");
         return jwtManager.issueRefreshToken(member.getId());
     }
 

--- a/src/test/java/eatda/controller/member/MemberControllerTest.java
+++ b/src/test/java/eatda/controller/member/MemberControllerTest.java
@@ -27,7 +27,7 @@ class MemberControllerTest extends BaseControllerTest {
         @Test
         void 중복된_닉네임을_확인할_수_있다() {
             String existingNickname = "existing-nickname";
-            memberGenerator.generateRegisteredMember("123", existingNickname, "01012345678");
+            memberGenerator.generateRegisteredMember(existingNickname, "hij@kakao.com", "123", "01012345678");
 
             given()
                     .header(HttpHeaders.AUTHORIZATION, accessToken())
@@ -54,7 +54,7 @@ class MemberControllerTest extends BaseControllerTest {
         @Test
         void 중복된_전화번호를_확인할_수_있다() {
             String existingPhoneNumber = "01012345678";
-            memberGenerator.generateRegisteredMember("123", "nickname", existingPhoneNumber);
+            memberGenerator.generateRegisteredMember("nickname", "hij@kakao.com", "123", existingPhoneNumber);
             given()
                     .header(HttpHeaders.AUTHORIZATION, accessToken())
                     .queryParam("phoneNumber", existingPhoneNumber)

--- a/src/test/java/eatda/document/auth/AuthDocumentTest.java
+++ b/src/test/java/eatda/document/auth/AuthDocumentTest.java
@@ -102,6 +102,7 @@ public class AuthDocumentTest extends BaseDocumentTest {
                         fieldWithPath("token.refreshToken").type(STRING).description("리프레시 토큰"),
                         fieldWithPath("information").type(OBJECT).description("유저 정보"),
                         fieldWithPath("information.id").type(NUMBER).description("유저 식별자"),
+                        fieldWithPath("information.email").type(STRING).description("유저 이메일"),
                         fieldWithPath("information.isSignUp").type(BOOLEAN).description("회원 가입 여부"),
                         fieldWithPath("information.nickname").type(STRING).description("유저 닉네임"),
                         fieldWithPath("information.phoneNumber").type(STRING).description("핸드폰 전화번호").optional(),
@@ -111,7 +112,7 @@ public class AuthDocumentTest extends BaseDocumentTest {
         @Test
         void 로그인_성공() {
             LoginRequest request = new LoginRequest("code", "http://localhost:3000");
-            MemberResponse response = new MemberResponse(1L, true, "닉네임", null, null);
+            MemberResponse response = new MemberResponse(1L, "abc@kakao.com", true, "닉네임", null, null);
             doReturn(response).when(authService).login(request);
 
             var document = document("auth/login", 201)

--- a/src/test/java/eatda/document/member/MemberDocumentTest.java
+++ b/src/test/java/eatda/document/member/MemberDocumentTest.java
@@ -145,6 +145,7 @@ public class MemberDocumentTest extends BaseDocumentTest {
         RestDocsResponse responseDocument = response()
                 .responseBodyField(
                         fieldWithPath("id").type(NUMBER).description("회원 식별자"),
+                        fieldWithPath("email").type(STRING).description("회원 이메일"),
                         fieldWithPath("isSignUp").type(BOOLEAN).description("회원 가입 요청 여부 (false 고정)"),
                         fieldWithPath("nickname").type(STRING).description("회원 닉네임").optional(),
                         fieldWithPath("phoneNumber").type(STRING).description("회원 전화번호 ex) 01012345678").optional(),
@@ -154,7 +155,7 @@ public class MemberDocumentTest extends BaseDocumentTest {
         @Test
         void 회원_정보_수정_성공() {
             MemberUpdateRequest request = new MemberUpdateRequest("update-nickname", "01012345678", true);
-            MemberResponse response = new MemberResponse(1L, false, "update-nickname", "01012345678", true);
+            MemberResponse response = new MemberResponse(1L, "abc@kakao.com", false, "update-nickname", "01012345678", true);
             doReturn(response).when(memberService).update(anyLong(), eq(request));
 
             var document = document("member/update", 200)

--- a/src/test/java/eatda/domain/bookmark/BookmarkTest.java
+++ b/src/test/java/eatda/domain/bookmark/BookmarkTest.java
@@ -21,7 +21,7 @@ class BookmarkTest {
 
         @Test
         void 정상적인_멤버와_가게로_북마크를_생성한다() {
-            Member member = new Member("socialId123", "nickname");
+            Member member = new Member("socialId123", "test@example.com", "nickname");
             Store store = new Store(
                     "가게명",
                     "양식",
@@ -65,7 +65,7 @@ class BookmarkTest {
 
         @Test
         void 가게가_null이면_예외를_던진다() {
-            Member member = new Member("socialId123", "nickname");
+            Member member = new Member("socialId123", "test@example.com", "nickname");
 
             BusinessException exception = assertThrows(BusinessException.class, () -> new Bookmark(member, null));
 

--- a/src/test/java/eatda/fixture/MemberGenerator.java
+++ b/src/test/java/eatda/fixture/MemberGenerator.java
@@ -1,12 +1,14 @@
 package eatda.fixture;
 
 import eatda.domain.member.Member;
-import eatda.enums.InterestArea;
 import eatda.repository.member.MemberRepository;
 import org.springframework.stereotype.Component;
 
 @Component
 public class MemberGenerator {
+
+    private static final String DEFAULT_NICKNAME = "nickname";
+    private static final String DEFAULT_EMAIL = "generatorEmail@example.com";
 
     private final MemberRepository memberRepository;
 
@@ -15,14 +17,22 @@ public class MemberGenerator {
     }
 
     public Member generate(String socialId) {
-        return memberRepository.save(new Member(socialId, "nickname"));
+        return memberRepository.save(new Member(socialId, DEFAULT_EMAIL, DEFAULT_NICKNAME));
     }
 
-    public Member generate(String socialId, String nickname) {
-        return memberRepository.save(new Member(socialId, nickname));
+    public Member generateByEmail(String socialId, String email) {
+        return memberRepository.save(new Member(socialId, email, DEFAULT_NICKNAME));
     }
 
-    public Member generateRegisteredMember(String socialId, String nickname, String phoneNumber) {
-        return memberRepository.save(new Member(socialId, nickname, phoneNumber, true));
+    public Member generateByNickname(String socialId, String nickname) {
+        return memberRepository.save(new Member(socialId, DEFAULT_EMAIL, nickname));
+    }
+
+    public Member generate(String socialId, String email, String nickname) {
+        return memberRepository.save(new Member(socialId, email, nickname));
+    }
+
+    public Member generateRegisteredMember(String nickname, String email, String socialId, String phoneNumber) {
+        return memberRepository.save(new Member(socialId, email, nickname, phoneNumber, true));
     }
 }

--- a/src/test/java/eatda/service/auth/AuthServiceTest.java
+++ b/src/test/java/eatda/service/auth/AuthServiceTest.java
@@ -21,7 +21,7 @@ class AuthServiceTest extends BaseServiceTest {
 
     private static final OauthToken DEFAULT_OAUTH_TOKEN = new OauthToken("oauth-access-token");
     private static final OauthMemberInformation DEFAULT_OAUTH_MEMBER_INFO =
-            new OauthMemberInformation(123L, "nickname");
+            new OauthMemberInformation(123L, "authService@kakao.com", "nickname");
 
     @Autowired
     private AuthService authService;

--- a/src/test/java/eatda/service/member/MemberServiceTest.java
+++ b/src/test/java/eatda/service/member/MemberServiceTest.java
@@ -25,8 +25,8 @@ class MemberServiceTest extends BaseServiceTest {
 
         @Test
         void 중복되지_않은_닉네임이면_예외가_발생하지_않는다() {
-            memberGenerator.generate("123", "nickname");
-            Member member = memberGenerator.generate("456", "unique-nickname");
+            memberGenerator.generate("123", "abc@kakao.com", "nickname");
+            Member member = memberGenerator.generate("456", "def@kakao.com", "unique-nickname");
             String newNickname = "new-unique-nickname";
 
             assertThatCode(() -> memberService.validateNickname(newNickname, member.getId()))
@@ -35,7 +35,7 @@ class MemberServiceTest extends BaseServiceTest {
 
         @Test
         void 자신의_기존_닉네임이면_예외가_발생하지_않는다() {
-            Member member = memberGenerator.generate("123", "nickname");
+            Member member = memberGenerator.generateByNickname("123", "nickname");
             String newNickname = "nickname";
 
             assertThatCode(() -> memberService.validateNickname(newNickname, member.getId()))
@@ -44,8 +44,8 @@ class MemberServiceTest extends BaseServiceTest {
 
         @Test
         void 중복된_닉네임이_있으면_예외가_발생한다() {
-            memberGenerator.generate("123", "duplicate-nickname");
-            Member member = memberGenerator.generate("456", "another-nickname");
+            memberGenerator.generate("123", "abc@kakao.com", "duplicate-nickname");
+            Member member = memberGenerator.generate("456", "def@kakao.com","another-nickname");
             String newNickname = "duplicate-nickname";
 
             BusinessException exception = assertThrows(BusinessException.class,
@@ -60,8 +60,8 @@ class MemberServiceTest extends BaseServiceTest {
 
         @Test
         void 중복되지_않은_전화번호이면_예외가_발생하지_않는다() {
-            memberGenerator.generate("123", "nickname");
-            Member member = memberGenerator.generate("456", "unique-nickname");
+            memberGenerator.generate("123", "abc@kakao.com","nickname");
+            Member member = memberGenerator.generate("456", "def@kakao.com","unique-nickname");
             String newPhoneNumber = "01012345678";
 
             assertThatCode(() -> memberService.validatePhoneNumber(newPhoneNumber, member.getId()))
@@ -70,7 +70,7 @@ class MemberServiceTest extends BaseServiceTest {
 
         @Test
         void 자신의_기존_전화번호이면_예외가_발생하지_않는다() {
-            Member member = memberGenerator.generateRegisteredMember("123", "nickname", "01012345678");
+            Member member = memberGenerator.generateRegisteredMember("nickname", "hij@kakao.com", "123", "01012345678");
             String newPhoneNumber = "01012345678";
 
             assertThatCode(() -> memberService.validatePhoneNumber(newPhoneNumber, member.getId()))
@@ -79,8 +79,8 @@ class MemberServiceTest extends BaseServiceTest {
 
         @Test
         void 중복된_전화번호가_있으면_예외가_발생한다() {
-            memberGenerator.generateRegisteredMember("123", "nickname1", "01012345678");
-            Member member = memberGenerator.generateRegisteredMember("456", "nickname2", "01087654321");
+            memberGenerator.generateRegisteredMember("nickname1", "abc@kakao.com", "123", "01012345678");
+            Member member = memberGenerator.generateRegisteredMember("nickname2", "def@kakao.com", "456", "01087654321");
             String newPhoneNumber = "01012345678";
 
             BusinessException exception = assertThrows(BusinessException.class,
@@ -111,8 +111,8 @@ class MemberServiceTest extends BaseServiceTest {
 
         @Test
         void 중복된_닉네임이_있으면_예외가_발생한다() {
-            Member existMember = memberGenerator.generate("123", "duplicate-nickname");
-            Member updatedMember = memberGenerator.generate("456");
+            Member existMember = memberGenerator.generate("123", "abc@kakao.com", "duplicate-nickname");
+            Member updatedMember = memberGenerator.generate("456", "def@kakao.com", "another-nickname");
             MemberUpdateRequest request =
                     new MemberUpdateRequest(existMember.getNickname(), "01012345678", true);
 
@@ -124,7 +124,7 @@ class MemberServiceTest extends BaseServiceTest {
 
         @Test
         void 기존의_닉네임과_동일하면_있으면_정상적으로_회원_정보가_수정된다() {
-            Member member = memberGenerator.generate("123", "duplicate-nickname");
+            Member member = memberGenerator.generateByNickname("123", "duplicate-nickname");
             MemberUpdateRequest request =
                     new MemberUpdateRequest(member.getNickname(), "01012345678", true);
 
@@ -136,8 +136,8 @@ class MemberServiceTest extends BaseServiceTest {
         @Test
         void 중복된_전화번호가_있으면_예외가_발생한다() {
             String phoneNumber = "01012345678";
-            memberGenerator.generateRegisteredMember("123", "nickname1", phoneNumber);
-            Member updatedMember = memberGenerator.generate("456", "nickname2");
+            memberGenerator.generateRegisteredMember("nickname1", "hij@kakao.com", "123", phoneNumber);
+            Member updatedMember = memberGenerator.generate("456", "abc@kakao.com", "nickname2");
             MemberUpdateRequest request =
                     new MemberUpdateRequest("new-nickname", phoneNumber, true);
 
@@ -150,7 +150,7 @@ class MemberServiceTest extends BaseServiceTest {
         @Test
         void 기존의_전화번호와_동일하면_정상적으로_회원_정보가_수정된다() {
             String phoneNumber = "01012345678";
-            Member member = memberGenerator.generateRegisteredMember("123", "nickname1", phoneNumber);
+            Member member = memberGenerator.generateRegisteredMember("nickname1", "hij@kakao.com", "123", phoneNumber);
             MemberUpdateRequest request =
                     new MemberUpdateRequest("new-nickname", phoneNumber, true);
 


### PR DESCRIPTION
## ✨ 개요
- 카카오 Oauth를 통해 이메일까지 같이 수집하도록 수정
- DB member 테이블에 이메일까지 같이 저장
- 회원 조회 관련 API에 이메일 정보까지 같이 반환

## 🧾 관련 이슈
closed #71 

## 🔍 참고 사항 (선택)
- 기존 데이터에도 이메일이 전부 필요할 것 같아서, DB 한 번 더 날려야 할 것 같아요 ㅠ_ㅠ
    -  그래서 Flyway V 버전 파일 수정을 진행했습니다.
    - 머지하기 전에 dev 환경 DB 날리는 것을 부탁드리겠습니다. 아니면 저에게 AWS 계정 접근할 수 있는 루트를 주시면 제가 dev DB 날리도록 하겠습니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 회원 정보에 이메일 필드가 추가되어 회원 생성, 응답, OAuth 연동 시 이메일이 포함됩니다.
  * 이메일 형식 유효성 검사가 적용되어 잘못된 이메일 입력 시 오류가 발생합니다.

* **버그 수정**
  * 회원 관련 오류 코드에 "유효하지 않은 이메일 형식"이 추가되었습니다.

* **문서화**
  * API 응답 및 테스트 문서에 이메일 필드가 반영되었습니다.

* **테스트**
  * 이메일 필드 추가에 따른 테스트 코드, 데이터 생성 로직, OAuth 테스트 및 시드 데이터가 업데이트되었습니다.

* **데이터베이스**
  * 회원 테이블에 이메일 컬럼이 추가되고, 초기 데이터에도 이메일 정보가 포함됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->