### PR TITLE
[Feat] 응원 조회 API 구현

### DIFF
--- a/src/main/java/eatda/controller/store/CheerController.java
+++ b/src/main/java/eatda/controller/store/CheerController.java
@@ -1,0 +1,21 @@
+package eatda.controller.store;
+
+import eatda.service.store.CheerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class CheerController {
+
+    private final CheerService cheerService;
+
+    @GetMapping("/api/cheer")
+    public ResponseEntity<CheersResponse> getCheers(@RequestParam int size) {
+        CheersResponse response = cheerService.getCheers(size);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/eatda/controller/store/CheerPreviewResponse.java
+++ b/src/main/java/eatda/controller/store/CheerPreviewResponse.java
@@ -1,0 +1,29 @@
+package eatda.controller.store;
+
+import eatda.domain.store.Cheer;
+import eatda.domain.store.Store;
+
+public record CheerPreviewResponse(
+        long storeId,
+        String storeImageUrl,
+        String storeName,
+        String storeDistrict,
+        String storeNeighborhood,
+        String storeCategory,
+        long cheerId,
+        String cheerDescription
+) {
+
+    public CheerPreviewResponse(Cheer cheer, Store store, String storeImageUrl) {
+        this(
+                store.getId(),
+                storeImageUrl,
+                store.getName(),
+                store.getAddressDistrict(),
+                store.getAddressNeighborhood(),
+                store.getCategory().getCategoryName(),
+                cheer.getId(),
+                cheer.getDescription()
+        );
+    }
+}

--- a/src/main/java/eatda/controller/store/CheerPreviewResponse.java
+++ b/src/main/java/eatda/controller/store/CheerPreviewResponse.java
@@ -5,7 +5,7 @@ import eatda.domain.store.Store;
 
 public record CheerPreviewResponse(
         long storeId,
-        String storeImageUrl,
+        String imageUrl,
         String storeName,
         String storeDistrict,
         String storeNeighborhood,
@@ -14,10 +14,10 @@ public record CheerPreviewResponse(
         String cheerDescription
 ) {
 
-    public CheerPreviewResponse(Cheer cheer, Store store, String storeImageUrl) {
+    public CheerPreviewResponse(Cheer cheer, Store store, String imageUrl) {
         this(
                 store.getId(),
-                storeImageUrl,
+                imageUrl,
                 store.getName(),
                 store.getAddressDistrict(),
                 store.getAddressNeighborhood(),

--- a/src/main/java/eatda/controller/store/CheersResponse.java
+++ b/src/main/java/eatda/controller/store/CheersResponse.java
@@ -1,0 +1,7 @@
+package eatda.controller.store;
+
+import java.util.List;
+
+public record CheersResponse(List<CheerPreviewResponse> cheers) {
+
+}

--- a/src/main/java/eatda/domain/store/Cheer.java
+++ b/src/main/java/eatda/domain/store/Cheer.java
@@ -13,7 +13,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -54,6 +53,11 @@ public class Cheer extends AuditingEntity {
         this.imageKey = imageKey;
 
         this.isAdmin = false;
+    }
+
+    public Cheer(Member member, Store store, String description, String imageKey, boolean isAdmin) {
+        this(member, store, description, imageKey);
+        this.isAdmin = isAdmin;
     }
 
     private void validateDescription(String description) {

--- a/src/main/java/eatda/domain/store/Store.java
+++ b/src/main/java/eatda/domain/store/Store.java
@@ -70,4 +70,12 @@ public class Store extends AuditingEntity {
         this.lotNumberAddress = lotNumberAddress;
         this.coordinates = new Coordinates(latitude, longitude);
     }
+
+    public String getAddressDistrict() {
+        return lotNumberAddress.split(" ")[1];
+    }
+
+    public String getAddressNeighborhood() {
+        return lotNumberAddress.split(" ")[2];
+    }
 }

--- a/src/main/java/eatda/repository/store/CheerRepository.java
+++ b/src/main/java/eatda/repository/store/CheerRepository.java
@@ -1,0 +1,11 @@
+package eatda.repository.store;
+
+import eatda.domain.store.Cheer;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CheerRepository extends JpaRepository<Cheer, Long> {
+
+    List<Cheer> findAllByOrderByCreatedAtDesc(Pageable pageable);
+}

--- a/src/main/java/eatda/repository/store/StoreRepository.java
+++ b/src/main/java/eatda/repository/store/StoreRepository.java
@@ -1,0 +1,8 @@
+package eatda.repository.store;
+
+import eatda.domain.store.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+
+}

--- a/src/main/java/eatda/service/common/ImageService.java
+++ b/src/main/java/eatda/service/common/ImageService.java
@@ -7,6 +7,7 @@ import java.time.Duration;
 import java.util.Set;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -65,13 +66,20 @@ public class ImageService {
     }
 
     private String getExtension(String filename) {
-        if (filename == null || filename.lastIndexOf(EXTENSION_DELIMITER) == -1 || filename.startsWith(EXTENSION_DELIMITER)) {
+        if (filename == null
+                || filename.lastIndexOf(EXTENSION_DELIMITER) == -1
+                || filename.startsWith(EXTENSION_DELIMITER)) {
             return "bin";
         }
         return filename.substring(filename.lastIndexOf(EXTENSION_DELIMITER) + 1);
     }
 
-    public String getPresignedUrl(String key) {
+    @Nullable
+    public String getPresignedUrl(@Nullable String key) {
+        if (key == null) {
+            return null;
+        }
+
         try {
             GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                     .bucket(bucket)

--- a/src/main/java/eatda/service/store/CheerService.java
+++ b/src/main/java/eatda/service/store/CheerService.java
@@ -1,0 +1,34 @@
+package eatda.service.store;
+
+import eatda.controller.store.CheerPreviewResponse;
+import eatda.controller.store.CheersResponse;
+import eatda.domain.store.Cheer;
+import eatda.repository.store.CheerRepository;
+import eatda.service.common.ImageService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CheerService {
+
+    private final ImageService imageService;
+    private final CheerRepository cheerRepository;
+
+    @Transactional(readOnly = true)
+    public CheersResponse getCheers(int size) {
+        PageRequest pageRequest = PageRequest.of(0, size);
+        List<Cheer> cheers = cheerRepository.findAllByOrderByCreatedAtDesc(pageRequest);
+        return toCheersResponse(cheers);
+    }
+
+    private CheersResponse toCheersResponse(List<Cheer> cheers) {
+        return new CheersResponse(cheers.stream()
+                .map(cheer -> new CheerPreviewResponse(cheer, cheer.getStore(),
+                        imageService.getPresignedUrl(cheer.getImageKey())))
+                .toList());
+    }
+}

--- a/src/test/java/eatda/controller/BaseControllerTest.java
+++ b/src/test/java/eatda/controller/BaseControllerTest.java
@@ -1,5 +1,6 @@
 package eatda.controller;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 
@@ -11,8 +12,13 @@ import eatda.client.oauth.OauthMemberInformation;
 import eatda.client.oauth.OauthToken;
 import eatda.controller.web.jwt.JwtManager;
 import eatda.domain.member.Member;
+import eatda.fixture.CheerGenerator;
 import eatda.fixture.MemberGenerator;
+import eatda.fixture.StoreGenerator;
 import eatda.repository.member.MemberRepository;
+import eatda.repository.store.CheerRepository;
+import eatda.repository.store.StoreRepository;
+import eatda.service.common.ImageService;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.filter.Filter;
@@ -38,12 +44,27 @@ public class BaseControllerTest {
     private static final OauthToken DEFAULT_OAUTH_TOKEN = new OauthToken("oauth-access-token");
     private static final OauthMemberInformation DEFAULT_OAUTH_MEMBER_INFO =
             new OauthMemberInformation(314159248183772L, "constant@kakao.com", "nickname");
+    private static final String MOCKED_IMAGE_KEY = "mocked-image-path";
+    private static final String MOCKED_IMAGE_URL = "https://example.com/image.jpg";
+
 
     @Autowired
     protected MemberGenerator memberGenerator;
 
     @Autowired
+    protected StoreGenerator storeGenerator;
+
+    @Autowired
+    protected CheerGenerator cheerGenerator;
+
+    @Autowired
     protected MemberRepository memberRepository;
+
+    @Autowired
+    protected StoreRepository storeRepository;
+
+    @Autowired
+    protected CheerRepository cheerRepository;
 
     @Autowired
     protected JwtManager jwtManager;
@@ -53,6 +74,9 @@ public class BaseControllerTest {
 
     @MockitoBean
     private MapClient mapClient;
+
+    @MockitoBean
+    private ImageService imageService;
 
     @LocalServerPort
     private int port;
@@ -80,6 +104,9 @@ public class BaseControllerTest {
                         "서울 중구 북창동 19-4", null, 37.0d, 128.0d)
         );
         doReturn(searchResults).when(mapClient).searchShops(anyString());
+
+        doReturn(MOCKED_IMAGE_URL).when(imageService).getPresignedUrl(anyString());
+        doReturn(MOCKED_IMAGE_KEY).when(imageService).upload(any(), any());
     }
 
     protected final RequestSpecification given() {

--- a/src/test/java/eatda/controller/store/CheerControllerTest.java
+++ b/src/test/java/eatda/controller/store/CheerControllerTest.java
@@ -1,0 +1,45 @@
+package eatda.controller.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import eatda.controller.BaseControllerTest;
+import eatda.domain.member.Member;
+import eatda.domain.store.Cheer;
+import eatda.domain.store.Store;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class CheerControllerTest extends BaseControllerTest {
+
+    @Nested
+    class GetCheers {
+
+        @Test
+        void 요청한_응원_중_최신_응원_N개를_조회한다() {
+            Member member = memberGenerator.generateRegisteredMember("nickname", "ac@kakao.com", "123", "01011111111");
+            Store store1 = storeGenerator.generate("111", "서울시 노원구 월계3동 123-45");
+            Store store2 = storeGenerator.generate("222", "서울시 성북구 석관동 123-45");
+            Cheer cheer1 = cheerGenerator.generateAdmin(member, store1);
+            Cheer cheer2 = cheerGenerator.generateAdmin(member, store1);
+            Cheer cheer3 = cheerGenerator.generateAdmin(member, store2);
+
+            CheersResponse response = given()
+                    .when()
+                    .queryParam("size", 2)
+                    .get("/api/cheer")
+                    .then()
+                    .statusCode(200)
+                    .extract().as(CheersResponse.class);
+
+            CheerPreviewResponse firstResponse = response.cheers().get(0);
+            assertAll(
+                    () -> assertThat(response.cheers()).hasSize(2),
+                    () -> assertThat(firstResponse.storeId()).isEqualTo(store2.getId()),
+                    () -> assertThat(firstResponse.storeDistrict()).isEqualTo("성북구"),
+                    () -> assertThat(firstResponse.storeNeighborhood()).isEqualTo("석관동"),
+                    () -> assertThat(firstResponse.cheerId()).isEqualTo(cheer3.getId())
+            );
+        }
+    }
+}

--- a/src/test/java/eatda/document/BaseDocumentTest.java
+++ b/src/test/java/eatda/document/BaseDocumentTest.java
@@ -8,6 +8,7 @@ import eatda.controller.web.jwt.JwtManager;
 import eatda.exception.BusinessErrorCode;
 import eatda.service.auth.AuthService;
 import eatda.service.member.MemberService;
+import eatda.service.store.CheerService;
 import eatda.service.store.StoreService;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
@@ -42,6 +43,8 @@ public abstract class BaseDocumentTest {
     protected MemberService memberService;
     @MockitoBean
     protected StoreService storeService;
+    @MockitoBean
+    protected CheerService cheerService;
     @MockitoBean
     protected JwtManager jwtManager;
     @LocalServerPort

--- a/src/test/java/eatda/document/Tag.java
+++ b/src/test/java/eatda/document/Tag.java
@@ -4,7 +4,9 @@ public enum Tag {
 
     AUTH_API("Auth API"),
     MEMBER_API("Member API"),
-    STORE_API("Store API"),;
+    STORE_API("Store API"),
+    CHEER_API("Cheer API"),
+    ;
 
     private final String displayName;
 

--- a/src/test/java/eatda/document/store/CheerDocumentTest.java
+++ b/src/test/java/eatda/document/store/CheerDocumentTest.java
@@ -1,0 +1,93 @@
+package eatda.document.store;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+
+import eatda.controller.store.CheerPreviewResponse;
+import eatda.controller.store.CheersResponse;
+import eatda.document.BaseDocumentTest;
+import eatda.document.RestDocsRequest;
+import eatda.document.RestDocsResponse;
+import eatda.document.Tag;
+import eatda.exception.BusinessErrorCode;
+import eatda.exception.BusinessException;
+import io.restassured.http.ContentType;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+public class CheerDocumentTest extends BaseDocumentTest {
+
+    @Nested
+    class Get {
+
+        RestDocsRequest requestDocument = request()
+                .tag(Tag.STORE_API)
+                .summary("최신 응원 검색")
+                .queryParameter(
+                        parameterWithName("size").description("조회 개수")
+                );
+
+        RestDocsResponse responseDocument = response()
+                .responseBodyField(
+                        fieldWithPath("cheers").type(ARRAY).description("응원 검색 결과"),
+                        fieldWithPath("cheers[].storeId").type(NUMBER).description("가게 ID"),
+                        fieldWithPath("cheers[].imageUrl").type(STRING).description("이미지 URL").optional(),
+                        fieldWithPath("cheers[].storeName").type(STRING).description("가게 이름"),
+                        fieldWithPath("cheers[].storeDistrict").type(STRING).description("가게 주소 (구)"),
+                        fieldWithPath("cheers[].storeNeighborhood").type(STRING).description("가게 주소 (동)"),
+                        fieldWithPath("cheers[].storeCategory").type(STRING).description("가게 카테고리"),
+                        fieldWithPath("cheers[].cheerId").type(NUMBER).description("응원 ID"),
+                        fieldWithPath("cheers[].cheerDescription").type(STRING).description("응원 내용")
+                );
+
+        @Test
+        void 음식점_검색_성공() {
+            int size = 2;
+            CheersResponse responses = new CheersResponse(List.of(
+                    new CheerPreviewResponse(2L, "https://example.image", "농민백암순대 본점", "강남구", "선릉구", "한식", 2L,
+                            "너무 맛있어요!"),
+                    new CheerPreviewResponse(1L, null, "석관동떡볶이", "성북구", "석관동", "기타", 1L,
+                            "너무 매워요! 하지만 맛있어요!")
+            ));
+            doReturn(responses).when(cheerService).getCheers(anyInt());
+
+            var document = document("cheer/get-many", 200)
+                    .request(requestDocument)
+                    .response(responseDocument)
+                    .build();
+
+            given(document)
+                    .contentType(ContentType.JSON)
+                    .queryParam("size", size)
+                    .when().get("/api/cheer")
+                    .then().statusCode(200);
+        }
+
+        @EnumSource(value = BusinessErrorCode.class, names = {"PRESIGNED_URL_GENERATION_FAILED"})
+        @ParameterizedTest
+        void 음식점_검색_실패(BusinessErrorCode errorCode) {
+            int size = 2;
+            doThrow(new BusinessException(errorCode)).when(cheerService).getCheers(anyInt());
+
+            var document = document("cheer/get-many", 200)
+                    .request(requestDocument)
+                    .response(ERROR_RESPONSE)
+                    .build();
+
+            given(document)
+                    .contentType(ContentType.JSON)
+                    .queryParam("size", size)
+                    .when().get("/api/cheer")
+                    .then().statusCode(errorCode.getStatus().value());
+        }
+    }
+}

--- a/src/test/java/eatda/domain/store/StoreTest.java
+++ b/src/test/java/eatda/domain/store/StoreTest.java
@@ -1,0 +1,50 @@
+package eatda.domain.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class StoreTest {
+
+    private static Store.StoreBuilder DEFAULT_BUILDER = Store.builder()
+            .kakaoId("123456789")
+            .category(StoreCategory.OTHER)
+            .phoneNumber("010-1234-5678")
+            .name("가게 이름")
+            .placeUrl("https://place.kakao.com/123456789")
+            .roadAddress("")
+            .lotNumberAddress("서울특별시 강남구 역삼동 123-45")
+            .latitude(37.5665)
+            .longitude(126.978);
+
+    @Nested
+    class GetAddressDistrict {
+
+        @Test
+        void 주소_구_정보를_지번_주소에서_반환한다() {
+            Store store = DEFAULT_BUILDER
+                    .lotNumberAddress("서울특별시 성북구 석관동 123-45")
+                    .build();;
+
+            String actual = store.getAddressDistrict();
+
+            assertThat(actual).isEqualTo("성북구");
+        }
+    }
+
+    @Nested
+    class GetAddressNeighborhood {
+
+        @Test
+        void 주소_동_정보를_지번_주소에서_반환한다() {
+            Store store = DEFAULT_BUILDER
+                    .lotNumberAddress("서울특별시 성북구 석관동 123-45")
+                    .build();
+
+            String actual = store.getAddressNeighborhood();
+
+            assertThat(actual).isEqualTo("석관동");
+        }
+    }
+}

--- a/src/test/java/eatda/fixture/CheerGenerator.java
+++ b/src/test/java/eatda/fixture/CheerGenerator.java
@@ -1,0 +1,30 @@
+package eatda.fixture;
+
+import eatda.domain.member.Member;
+import eatda.domain.store.Cheer;
+import eatda.domain.store.Store;
+import eatda.repository.store.CheerRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CheerGenerator {
+
+    private static final String DEFAULT_IMAGE_KEY = "default-image-key";
+    private static final String DEFAULT_DESCRIPTION = "응원합니다!";
+
+    private final CheerRepository cheerRepository;
+
+    public CheerGenerator(CheerRepository cheerRepository) {
+        this.cheerRepository = cheerRepository;
+    }
+
+    public Cheer generateAdmin(Member member, Store store) {
+        Cheer cheer = new Cheer(member, store, DEFAULT_IMAGE_KEY, DEFAULT_DESCRIPTION, true);
+        return cheerRepository.save(cheer);
+    }
+
+    public Cheer generateCommon(Member member, Store store) {
+        Cheer cheer = new Cheer(member, store, DEFAULT_IMAGE_KEY, DEFAULT_DESCRIPTION, false);
+        return cheerRepository.save(cheer);
+    }
+}

--- a/src/test/java/eatda/fixture/StoreGenerator.java
+++ b/src/test/java/eatda/fixture/StoreGenerator.java
@@ -1,0 +1,40 @@
+package eatda.fixture;
+
+import eatda.domain.store.Store;
+import eatda.domain.store.StoreCategory;
+import eatda.repository.store.StoreRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StoreGenerator {
+
+    private static final StoreCategory DEFAULT_CATEGORY = StoreCategory.OTHER;
+    private static final String DEFAULT_PHONE_NUMBER = "010-1234-5678";
+    private static final String DEFAULT_NAME = "가게 이름";
+    private static final String DEFAULT_PALCE_URL = "https://place.kakao.com/123456789";
+    private static final String DEFAULT_ROAD_ADDRESS = "";
+
+    private static final double DEFAULT_LATITUDE = 37.5665; // Default latitude for Seoul
+    private static final double DEFAULT_LONGITUDE = 126.978; // Default longitude for Seoul
+
+    private final StoreRepository storeRepository;
+
+    public StoreGenerator(StoreRepository storeRepository) {
+        this.storeRepository = storeRepository;
+    }
+
+    public Store generate(String kakaoId, String lotNumberAddress) {
+        Store store = Store.builder()
+                .kakaoId(kakaoId)
+                .category(DEFAULT_CATEGORY)
+                .phoneNumber(DEFAULT_PHONE_NUMBER)
+                .name(DEFAULT_NAME)
+                .placeUrl(DEFAULT_PALCE_URL)
+                .roadAddress(DEFAULT_ROAD_ADDRESS)
+                .lotNumberAddress(lotNumberAddress)
+                .latitude(DEFAULT_LATITUDE)
+                .longitude(DEFAULT_LONGITUDE)
+                .build();
+        return storeRepository.save(store);
+    }
+}

--- a/src/test/java/eatda/service/BaseServiceTest.java
+++ b/src/test/java/eatda/service/BaseServiceTest.java
@@ -1,10 +1,20 @@
 package eatda.service;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+
 import eatda.DatabaseCleaner;
 import eatda.client.map.MapClient;
 import eatda.client.oauth.OauthClient;
+import eatda.fixture.CheerGenerator;
 import eatda.fixture.MemberGenerator;
+import eatda.fixture.StoreGenerator;
 import eatda.repository.member.MemberRepository;
+import eatda.repository.store.CheerRepository;
+import eatda.repository.store.StoreRepository;
+import eatda.service.common.ImageService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,8 +24,14 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 public abstract class BaseServiceTest {
 
+    private static final String MOCKED_IMAGE_KEY = "mocked-image-path";
+    private static final String MOCKED_IMAGE_URL = "https://example.com/image.jpg";
+
     @MockitoBean
     protected OauthClient oauthClient;
+
+    @MockitoBean
+    protected ImageService imageService;
 
     @MockitoBean
     protected MapClient mapClient;
@@ -24,5 +40,23 @@ public abstract class BaseServiceTest {
     protected MemberGenerator memberGenerator;
 
     @Autowired
+    protected StoreGenerator storeGenerator;
+
+    @Autowired
+    protected CheerGenerator cheerGenerator;
+
+    @Autowired
     protected MemberRepository memberRepository;
+
+    @Autowired
+    protected StoreRepository storeRepository;
+
+    @Autowired
+    protected CheerRepository cheerRepository;
+
+    @BeforeEach
+    void mockingImageService() {
+        doReturn(MOCKED_IMAGE_URL).when(imageService).getPresignedUrl(anyString());
+        doReturn(MOCKED_IMAGE_KEY).when(imageService).upload(any(), any());
+    }
 }

--- a/src/test/java/eatda/service/store/CheerServiceTest.java
+++ b/src/test/java/eatda/service/store/CheerServiceTest.java
@@ -1,0 +1,41 @@
+package eatda.service.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import eatda.controller.store.CheersResponse;
+import eatda.domain.member.Member;
+import eatda.domain.store.Cheer;
+import eatda.domain.store.Store;
+import eatda.service.BaseServiceTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class CheerServiceTest extends BaseServiceTest {
+
+    @Autowired
+    private CheerService cheerService;
+
+    @Nested
+    class GetCheers {
+
+        @Test
+        void 요청한_응원_개수만큼_응원을_최신순으로_반환한다() {
+            Member member = memberGenerator.generate("123");
+            Store store1 = storeGenerator.generate("123", "서울시 강남구 역삼동 123-45");
+            Store store2 = storeGenerator.generate("456", "서울시 성북구 석관동 123-45");
+            Cheer cheer1 = cheerGenerator.generateAdmin(member, store1);
+            Cheer cheer2 = cheerGenerator.generateAdmin(member, store1);
+            Cheer cheer3 = cheerGenerator.generateAdmin(member, store2);
+
+            CheersResponse response = cheerService.getCheers(2);
+
+            assertAll(
+                    () -> assertThat(response.cheers()).hasSize(2),
+                    () -> assertThat(response.cheers().get(0).cheerId()).isEqualTo(cheer3.getId()),
+                    () -> assertThat(response.cheers().get(1).cheerId()).isEqualTo(cheer2.getId())
+            );
+        }
+    }
+}


### PR DESCRIPTION
## ✨ 개요
- 응원 다수 조회 API 구현하였습니다!
- ServiceTest, ControllerTest 환경에서 imageService mocking 진행했습니다!
- `isAdmin` 만 보이도록 하는 기능은 추후에 구현하도록 하겠습니다!

## 🧾 관련 이슈
closed #77 

## 🔍 참고 사항 (선택)
