### PR TITLE
[Feat] 가게 조회 API 구현

### DIFF
--- a/src/main/java/eatda/controller/store/StoreController.java
+++ b/src/main/java/eatda/controller/store/StoreController.java
@@ -2,6 +2,8 @@ package eatda.controller.store;
 
 import eatda.controller.web.auth.LoginMember;
 import eatda.service.store.StoreService;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,6 +15,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class StoreController {
 
     private final StoreService storeService;
+
+    @GetMapping("/api/shops")
+    public ResponseEntity<StoresResponse> getStores(@RequestParam @Min(1) @Max(50) int size) {
+        return ResponseEntity.ok(storeService.getStores(size));
+    }
 
     @GetMapping("/api/shop/search")
     public ResponseEntity<StoreSearchResponses> searchStore(@RequestParam String query, LoginMember member) {

--- a/src/main/java/eatda/controller/store/StorePreviewResponse.java
+++ b/src/main/java/eatda/controller/store/StorePreviewResponse.java
@@ -1,0 +1,24 @@
+package eatda.controller.store;
+
+import eatda.domain.store.Store;
+
+public record StorePreviewResponse(
+        long id,
+        String imageUrl,
+        String name,
+        String district,
+        String neighborhood,
+        String category
+) {
+
+    public StorePreviewResponse(Store store, String imageUrl) {
+        this(
+                store.getId(),
+                imageUrl,
+                store.getName(),
+                store.getAddressDistrict(),
+                store.getAddressNeighborhood(),
+                store.getCategory().getCategoryName()
+        );
+    }
+}

--- a/src/main/java/eatda/controller/store/StoresResponse.java
+++ b/src/main/java/eatda/controller/store/StoresResponse.java
@@ -1,0 +1,6 @@
+package eatda.controller.store;
+
+import java.util.List;
+
+public record StoresResponse(List<StorePreviewResponse> stores) {
+}

--- a/src/main/java/eatda/repository/store/CheerRepository.java
+++ b/src/main/java/eatda/repository/store/CheerRepository.java
@@ -1,8 +1,11 @@
 package eatda.repository.store;
 
 import eatda.domain.store.Cheer;
+import eatda.domain.store.Store;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
 public interface CheerRepository extends Repository<Cheer, Long> {
@@ -10,4 +13,11 @@ public interface CheerRepository extends Repository<Cheer, Long> {
     Cheer save(Cheer cheer);
 
     List<Cheer> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    @Query("""
+    SELECT c.imageKey FROM Cheer c
+        WHERE c.store = :store AND c.imageKey IS NOT NULL
+        ORDER BY c.createdAt DESC
+        LIMIT 1""")
+    Optional<String> findRecentImageKey(Store store);
 }

--- a/src/main/java/eatda/repository/store/StoreRepository.java
+++ b/src/main/java/eatda/repository/store/StoreRepository.java
@@ -1,9 +1,13 @@
 package eatda.repository.store;
 
 import eatda.domain.store.Store;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.Repository;
 
 public interface StoreRepository extends Repository<Store, Long> {
 
     Store save(Store store);
+
+    List<Store> findAllByOrderByCreatedAtDesc(Pageable pageable);
 }

--- a/src/main/java/eatda/service/store/CheerService.java
+++ b/src/main/java/eatda/service/store/CheerService.java
@@ -7,7 +7,7 @@ import eatda.repository.store.CheerRepository;
 import eatda.service.common.ImageService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,8 +20,7 @@ public class CheerService {
 
     @Transactional(readOnly = true)
     public CheersResponse getCheers(int size) {
-        PageRequest pageRequest = PageRequest.of(0, size);
-        List<Cheer> cheers = cheerRepository.findAllByOrderByCreatedAtDesc(pageRequest);
+        List<Cheer> cheers = cheerRepository.findAllByOrderByCreatedAtDesc(Pageable.ofSize(size));
         return toCheersResponse(cheers);
     }
 

--- a/src/main/java/eatda/service/store/StoreService.java
+++ b/src/main/java/eatda/service/store/StoreService.java
@@ -1,10 +1,21 @@
 package eatda.service.store;
 
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toList;
+
 import eatda.client.map.MapClient;
 import eatda.client.map.StoreSearchResult;
+import eatda.controller.store.StorePreviewResponse;
 import eatda.controller.store.StoreSearchResponses;
+import eatda.controller.store.StoresResponse;
+import eatda.domain.store.Store;
+import eatda.repository.store.CheerRepository;
+import eatda.repository.store.StoreRepository;
+import eatda.service.common.ImageService;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -13,6 +24,22 @@ public class StoreService {
 
     private final MapClient mapClient;
     private final StoreSearchFilter storeSearchFilter;
+    private final StoreRepository storeRepository;
+    private final CheerRepository cheerRepository;
+    private final ImageService imageService;
+
+    // TODO : N+1 문제 해결
+    public StoresResponse getStores(int size) {
+        return storeRepository.findAllByOrderByCreatedAtDesc(Pageable.ofSize(size))
+                .stream()
+                .map(store -> new StorePreviewResponse(store, getStoreImageUrl(store).orElse(null)))
+                .collect(collectingAndThen(toList(), StoresResponse::new));
+    }
+
+    private Optional<String> getStoreImageUrl(Store store) {
+        return cheerRepository.findRecentImageKey(store)
+                .map(imageService::getPresignedUrl);
+    }
 
     public StoreSearchResponses searchStores(String query) {
         List<StoreSearchResult> searchResults = mapClient.searchShops(query);

--- a/src/test/java/eatda/controller/store/StoreControllerTest.java
+++ b/src/test/java/eatda/controller/store/StoreControllerTest.java
@@ -1,13 +1,47 @@
 package eatda.controller.store;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import eatda.controller.BaseControllerTest;
+import eatda.domain.member.Member;
+import eatda.domain.store.Store;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 
 class StoreControllerTest extends BaseControllerTest {
+
+    @Nested
+    class GetStores {
+
+        @Test
+        void 음식점_목록을_최신순으로_조회한다() {
+            Member member = memberGenerator.generate("111");
+            Store store1 = storeGenerator.generate("111", "서울 강남구 대치동 896-33");
+            Store store2 = storeGenerator.generate("222", "서울 강남구 대치동 896-34");
+            Store store3 = storeGenerator.generate("333", "서울 강남구 대치동 896-35");
+            cheerGenerator.generateCommon(member, store1, "image-key-1");
+            cheerGenerator.generateCommon(member, store2, "image-key-2");
+            cheerGenerator.generateCommon(member, store3, "image-key-3");
+
+            int size = 2;
+
+            StoresResponse response = given()
+                    .queryParam("size", size)
+                    .when()
+                    .get("/api/shops")
+                    .then()
+                    .statusCode(200)
+                    .extract().as(StoresResponse.class);
+
+            assertAll(
+                    () -> assertThat(response.stores()).hasSize(size),
+                    () -> assertThat(response.stores().get(0).id()).isEqualTo(store3.getId()),
+                    () -> assertThat(response.stores().get(1).id()).isEqualTo(store2.getId())
+            );
+        }
+    }
 
     @Nested
     class SearchStores {

--- a/src/test/java/eatda/fixture/CheerGenerator.java
+++ b/src/test/java/eatda/fixture/CheerGenerator.java
@@ -19,12 +19,16 @@ public class CheerGenerator {
     }
 
     public Cheer generateAdmin(Member member, Store store) {
-        Cheer cheer = new Cheer(member, store, DEFAULT_IMAGE_KEY, DEFAULT_DESCRIPTION, true);
+        Cheer cheer = new Cheer(member, store, DEFAULT_DESCRIPTION, DEFAULT_IMAGE_KEY, true);
         return cheerRepository.save(cheer);
     }
 
     public Cheer generateCommon(Member member, Store store) {
-        Cheer cheer = new Cheer(member, store, DEFAULT_IMAGE_KEY, DEFAULT_DESCRIPTION, false);
+        return generateCommon(member, store, DEFAULT_IMAGE_KEY);
+    }
+
+    public Cheer generateCommon(Member member, Store store, String imageKey) {
+        Cheer cheer = new Cheer(member, store, DEFAULT_DESCRIPTION, imageKey, false);
         return cheerRepository.save(cheer);
     }
 }

--- a/src/test/java/eatda/repository/BaseRepositoryTest.java
+++ b/src/test/java/eatda/repository/BaseRepositoryTest.java
@@ -1,10 +1,17 @@
 package eatda.repository;
 
+import eatda.fixture.CheerGenerator;
 import eatda.fixture.MemberGenerator;
+import eatda.fixture.StoreGenerator;
 import eatda.repository.member.MemberRepository;
+import eatda.repository.store.CheerRepository;
+import eatda.repository.store.StoreRepository;
+import eatda.repository.story.StoryRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
+@Import({MemberGenerator.class, StoreGenerator.class, CheerGenerator.class})
 @DataJpaTest
 public abstract class BaseRepositoryTest {
 
@@ -12,5 +19,20 @@ public abstract class BaseRepositoryTest {
     protected MemberGenerator memberGenerator;
 
     @Autowired
+    protected StoreGenerator storeGenerator;
+
+    @Autowired
+    protected CheerGenerator cheerGenerator;
+
+    @Autowired
     protected MemberRepository memberRepository;
+
+    @Autowired
+    protected StoreRepository storeRepository;
+
+    @Autowired
+    protected CheerRepository cheerRepository;
+
+    @Autowired
+    protected StoryRepository storyRepository;
 }

--- a/src/test/java/eatda/repository/store/CheerRepositoryTest.java
+++ b/src/test/java/eatda/repository/store/CheerRepositoryTest.java
@@ -1,0 +1,44 @@
+package eatda.repository.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import eatda.domain.member.Member;
+import eatda.domain.store.Store;
+import eatda.repository.BaseRepositoryTest;
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class CheerRepositoryTest extends BaseRepositoryTest {
+
+    @Nested
+    class FindRecentImageKey {
+
+        @Test
+        void 응원들_중_최근_null이_아닌_이미지_키를_조회한다() throws InterruptedException {
+            Member member = memberGenerator.generate("111");
+            Store store = storeGenerator.generate("농민백암순대", "서울 강남구 대치동 896-33");
+            cheerGenerator.generateCommon(member, store, "image-key-1");
+            Thread.sleep(5);
+            cheerGenerator.generateCommon(member, store, "image-key-2");
+            cheerGenerator.generateCommon(member, store, null);
+
+            Optional<String> imageKey = cheerRepository.findRecentImageKey(store);
+
+            assertThat(imageKey).contains("image-key-2");
+        }
+
+        @Test
+        void 응원들의_이미지가_모두_비어있다면_해당_값이_없다() {
+            Member member = memberGenerator.generate("111");
+            Store store = storeGenerator.generate("농민백암순대", "서울 강남구 대치동 896-33");
+            cheerGenerator.generateCommon(member, store, null);
+            cheerGenerator.generateCommon(member, store, null);
+            cheerGenerator.generateCommon(member, store, null);
+
+            Optional<String> imageKey = cheerRepository.findRecentImageKey(store);
+
+            assertThat(imageKey).isEmpty();
+        }
+    }
+}

--- a/src/test/java/eatda/service/store/StoreServiceTest.java
+++ b/src/test/java/eatda/service/store/StoreServiceTest.java
@@ -11,8 +11,12 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 class StoreServiceTest extends BaseServiceTest {
+
+    @Autowired
+    private StoreService storeService;
 
     @BeforeEach
     void mockingClient() {
@@ -31,7 +35,6 @@ class StoreServiceTest extends BaseServiceTest {
 
         @Test
         void 음식점_검색_결과를_반환한다() {
-            StoreService storeService = new StoreService(mapClient, new StoreSearchFilter());
             String query = "농민백암순대";
 
             var response = storeService.searchStores(query);

--- a/src/test/java/eatda/service/store/StoreServiceTest.java
+++ b/src/test/java/eatda/service/store/StoreServiceTest.java
@@ -6,9 +6,10 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 
 import eatda.client.map.StoreSearchResult;
+import eatda.domain.member.Member;
+import eatda.domain.store.Store;
 import eatda.service.BaseServiceTest;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,16 +19,29 @@ class StoreServiceTest extends BaseServiceTest {
     @Autowired
     private StoreService storeService;
 
-    @BeforeEach
-    void mockingClient() {
-        List<StoreSearchResult> searchResults = List.of(
-                new StoreSearchResult("123", "FD6", "음식점 > 한식 > 국밥", "010-1234-1234", "농민백암순대 본점", "https://yapp.co.kr",
-                        "서울 강남구 대치동 896-33", "서울 강남구 선릉로86길 40-4", 37.0d, 128.0d),
-                new StoreSearchResult("456", "FD6", "음식점 > 한식 > 국밥", "010-1234-1234", "농민백암순대 시청점", "http://yapp.kr",
-                        "서울 중구 북창동 19-4", null, 37.0d, 128.0d)
-        );
+    @Nested
+    class GetStores {
 
-        doReturn(searchResults).when(mapClient).searchShops(anyString());
+        @Test
+        void 음식점_목록을_최신순으로_조회한다() {
+            Member member = memberGenerator.generate("111");
+            Store store1 = storeGenerator.generate("농민백암순대", "서울 강남구 대치동 896-33");
+            cheerGenerator.generateCommon(member, store1, "image-key-1");
+            Store store2 = storeGenerator.generate("석관동떡볶이", "서울 성북구 석관동 123-45");
+            cheerGenerator.generateCommon(member, store2, "image-key-2");
+            Store store3 = storeGenerator.generate("강남순대국", "서울 강남구 역삼동 678-90");
+            cheerGenerator.generateCommon(member, store3, "image-key-3");
+
+            int size = 2;
+
+            var response = storeService.getStores(size);
+
+            assertAll(
+                    () -> assertThat(response.stores()).hasSize(size),
+                    () -> assertThat(response.stores().get(0).id()).isEqualTo(store3.getId()),
+                    () -> assertThat(response.stores().get(1).id()).isEqualTo(store2.getId())
+            );
+        }
     }
 
     @Nested
@@ -35,6 +49,7 @@ class StoreServiceTest extends BaseServiceTest {
 
         @Test
         void 음식점_검색_결과를_반환한다() {
+            mockingMapClient();
             String query = "농민백암순대";
 
             var response = storeService.searchStores(query);
@@ -47,5 +62,16 @@ class StoreServiceTest extends BaseServiceTest {
                     () -> assertThat(response.stores().get(1).address()).isEqualTo("서울 중구 북창동 19-4")
             );
         }
+    }
+
+    void mockingMapClient() {
+        List<StoreSearchResult> searchResults = List.of(
+                new StoreSearchResult("123", "FD6", "음식점 > 한식 > 국밥", "010-1234-1234", "농민백암순대 본점", "https://yapp.co.kr",
+                        "서울 강남구 대치동 896-33", "서울 강남구 선릉로86길 40-4", 37.0d, 128.0d),
+                new StoreSearchResult("456", "FD6", "음식점 > 한식 > 국밥", "010-1234-1234", "농민백암순대 시청점", "http://yapp.kr",
+                        "서울 중구 북창동 19-4", null, 37.0d, 128.0d)
+        );
+
+        doReturn(searchResults).when(mapClient).searchShops(anyString());
     }
 }


### PR DESCRIPTION
## ✨ 개요
- 홈 화면에서 사용할 가게 조회 API 구현
- 페이지네이션이 필요하다면 추후 추가 예정

## 🧾 관련 이슈
closed #78 

## 🔍 참고 사항 (선택)
- 특정 가게 이미지 조회 방식 : image_key가 null 이 아닌 최신 응원을 사용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * `/api/shops` 엔드포인트를 통해 음식점 목록을 최신순으로 조회할 수 있는 기능이 추가되었습니다. 조회 결과에는 음식점의 대표 이미지, 이름, 지역, 카테고리 정보가 포함됩니다.

* **버그 수정**
  * 없음

* **테스트**
  * 음식점 목록 조회 API의 정상 및 예외 상황 테스트가 추가되었습니다.
  * 음식점 대표 이미지 조회 로직에 대한 리포지토리 테스트가 추가되었습니다.

* **문서화**
  * 음식점 목록 조회 API의 요청 및 응답 구조에 대한 문서화 테스트가 추가되었습니다.

* **리팩터링/환경 개선**
  * 테스트 환경의 의존성 및 데이터 생성 유틸리티가 확장되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->