### PR TITLE
[Fix] 스토리 등록 로직 수정

### DIFF
--- a/src/main/java/eatda/controller/story/StoryController.java
+++ b/src/main/java/eatda/controller/story/StoryController.java
@@ -22,13 +22,13 @@ public class StoryController {
     private final StoryService storyService;
 
     @PostMapping("/api/stories")
-    public ResponseEntity<Void> registerStory(
+    public ResponseEntity<StoryRegisterResponse> registerStory(
             @RequestPart("request") StoryRegisterRequest request,
             @RequestPart("image") MultipartFile image,
             LoginMember member
     ) {
-        storyService.registerStory(request, image, member.id());
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(storyService.registerStory(request, image, member.id()));
     }
 
     @GetMapping("api/stories")

--- a/src/main/java/eatda/controller/story/StoryRegisterResponse.java
+++ b/src/main/java/eatda/controller/story/StoryRegisterResponse.java
@@ -1,0 +1,6 @@
+package eatda.controller.story;
+
+public record StoryRegisterResponse(
+        long storyId
+) {
+}

--- a/src/main/java/eatda/service/story/StoryService.java
+++ b/src/main/java/eatda/service/story/StoryService.java
@@ -4,6 +4,7 @@ import eatda.client.map.StoreSearchResult;
 import eatda.controller.story.FilteredSearchResult;
 import eatda.controller.story.StoriesResponse;
 import eatda.controller.story.StoryRegisterRequest;
+import eatda.controller.story.StoryRegisterResponse;
 import eatda.controller.story.StoryResponse;
 import eatda.domain.member.Member;
 import eatda.domain.story.Story;
@@ -34,7 +35,7 @@ public class StoryService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public void registerStory(StoryRegisterRequest request, MultipartFile image, Long memberId) {
+    public StoryRegisterResponse registerStory(StoryRegisterRequest request, MultipartFile image, Long memberId) {
         Member member = memberRepository.getById(memberId);
         List<StoreSearchResult> searchResponses = storeService.searchStoreResults(request.query());
         FilteredSearchResult matchedStore = filteredSearchResponse(searchResponses, request.storeKakaoId());
@@ -52,6 +53,8 @@ public class StoryService {
                 .build();
 
         storyRepository.save(story);
+
+        return new StoryRegisterResponse(story.getId());
     }
 
     private FilteredSearchResult filteredSearchResponse(List<StoreSearchResult> responses, String storeKakaoId) {

--- a/src/test/java/eatda/controller/story/StoryControllerTest.java
+++ b/src/test/java/eatda/controller/story/StoryControllerTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 
@@ -22,7 +21,7 @@ public class StoryControllerTest extends BaseControllerTest {
 
     @BeforeEach
     void setUpMock() {
-        doNothing()
+        doReturn(new StoryRegisterResponse(1L))
                 .when(storyService)
                 .registerStory(any(), any(), any());
     }
@@ -42,6 +41,10 @@ public class StoryControllerTest extends BaseControllerTest {
 
             byte[] imageBytes = "dummy image content".getBytes(StandardCharsets.UTF_8);
 
+            doReturn(new StoryRegisterResponse(123L))
+                    .when(storyService)
+                    .registerStory(any(), any(), any());
+
             Response response = given()
                     .contentType("multipart/form-data")
                     .header("Authorization", accessToken())
@@ -50,7 +53,9 @@ public class StoryControllerTest extends BaseControllerTest {
                     .when()
                     .post("/api/stories");
 
-            response.then().statusCode(201);
+            response.then()
+                    .statusCode(201)
+                    .body("storyId", equalTo(123));
         }
     }
 

--- a/src/test/java/eatda/document/story/StoryDocumentTest.java
+++ b/src/test/java/eatda/document/story/StoryDocumentTest.java
@@ -2,13 +2,13 @@ package eatda.document.story;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
 import eatda.controller.story.StoriesResponse;
+import eatda.controller.story.StoryRegisterResponse;
 import eatda.controller.story.StoryResponse;
 import eatda.document.BaseDocumentTest;
 import eatda.document.RestDocsRequest;
@@ -39,7 +39,10 @@ public class StoryDocumentTest extends BaseDocumentTest {
                         headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
                 );
 
-        RestDocsResponse responseDocument = response();
+        RestDocsResponse responseDocument = response()
+                .responseBodyField(
+                        fieldWithPath("storyId").description("등록된 스토리의 ID")
+                );
 
         @Test
         void 스토리_등록_성공() {
@@ -47,7 +50,8 @@ public class StoryDocumentTest extends BaseDocumentTest {
                     .when(imageService)
                     .upload(any(), org.mockito.ArgumentMatchers.eq(ImageDomain.STORY));
 
-            doNothing().when(storyService)
+            doReturn(new StoryRegisterResponse(123L))
+                    .when(storyService)
                     .registerStory(any(), any(), any());
 
             String requestJson = """
@@ -72,7 +76,9 @@ public class StoryDocumentTest extends BaseDocumentTest {
                     .multiPart("image", "image.png", imageBytes, "image/png")
                     .when().post("/api/stories");
 
-            response.then().statusCode(201);
+            response.then()
+                    .statusCode(201)
+                    .body("storyId", equalTo(123));
         }
 
         @Test

--- a/src/test/java/eatda/service/story/StoryServiceTest.java
+++ b/src/test/java/eatda/service/story/StoryServiceTest.java
@@ -2,7 +2,6 @@ package eatda.service.story;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -48,7 +47,9 @@ public class StoryServiceTest extends BaseServiceTest {
             doReturn(List.of(store)).when(mapClient).searchShops(request.query());
             when(imageService.upload(image, ImageDomain.STORY)).thenReturn("image-key");
 
-            assertDoesNotThrow(() -> storyService.registerStory(request, image, member.getId()));
+            var response = storyService.registerStory(request, image, member.getId());
+
+            assertThat(storyRepository.existsById(response.storyId())).isTrue();
         }
 
         @Test


### PR DESCRIPTION
## ✨ 개요
- 기획에서 스토리 등록 후 스토리 상세페이지로 리다이렉트 되는것으로 변경되어 응답 구조를 변경했습니다.
- 이전 PR과 충돌 날수 있으니 이번 PR이 먼저 merge 되는게 낫지 않을까 싶긴 합니다.

## 🧾 관련 이슈
#92 

## 🔍 참고 사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 스토리 등록 시 응답 본문에 storyId가 포함되어 반환됩니다.

* **버그 수정**
  * 스토리 등록 관련 테스트가 실제로 반환된 storyId를 검증하도록 개선되었습니다.

* **테스트**
  * 스토리 등록 API의 응답 본문에 storyId가 포함되는지 확인하는 테스트가 추가 및 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->