### PR TITLE
[Feat] 가게 상세 정보 조회 API 구현

### DIFF
--- a/src/main/java/eatda/controller/store/StoreController.java
+++ b/src/main/java/eatda/controller/store/StoreController.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,6 +20,12 @@ public class StoreController {
     @GetMapping("/api/shops")
     public ResponseEntity<StoresResponse> getStores(@RequestParam @Min(1) @Max(50) int size) {
         return ResponseEntity.ok(storeService.getStores(size));
+    }
+
+    @GetMapping("/api/shops/{storeId}")
+    public ResponseEntity<StoreResponse> getStore(@PathVariable long storeId) {
+        StoreResponse response = storeService.getStore(storeId);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/api/shop/search")

--- a/src/main/java/eatda/controller/store/StoreResponse.java
+++ b/src/main/java/eatda/controller/store/StoreResponse.java
@@ -1,0 +1,26 @@
+package eatda.controller.store;
+
+import eatda.domain.store.Store;
+
+public record StoreResponse(
+        long id,
+        String kakaoId,
+        String name,
+        String district,
+        String neighborhood,
+        String category,
+        String placeUrl
+) {
+
+    public StoreResponse(Store store) {
+        this(
+                store.getId(),
+                store.getKakaoId(),
+                store.getName(),
+                store.getAddressDistrict(),
+                store.getAddressNeighborhood(),
+                store.getCategory().getCategoryName(),
+                store.getPlaceUrl()
+        );
+    }
+}

--- a/src/main/java/eatda/repository/store/StoreRepository.java
+++ b/src/main/java/eatda/repository/store/StoreRepository.java
@@ -1,14 +1,20 @@
 package eatda.repository.store;
 
 import eatda.domain.store.Store;
+import eatda.exception.BusinessErrorCode;
+import eatda.exception.BusinessException;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.repository.Repository;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StoreRepository extends Repository<Store, Long> {
+public interface StoreRepository extends JpaRepository<Store, Long> {
 
-    Store save(Store store);
+    @Override
+    default Store getById(Long id) {
+        return findById(id)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.STORE_NOT_FOUND));
+    }
 
     Optional<Store> findByKakaoId(String kakaoId);
 

--- a/src/main/java/eatda/service/store/StoreService.java
+++ b/src/main/java/eatda/service/store/StoreService.java
@@ -6,6 +6,7 @@ import static java.util.stream.Collectors.toList;
 import eatda.client.map.MapClient;
 import eatda.client.map.StoreSearchResult;
 import eatda.controller.store.StorePreviewResponse;
+import eatda.controller.store.StoreResponse;
 import eatda.controller.store.StoreSearchResponses;
 import eatda.controller.store.StoresResponse;
 import eatda.domain.store.Store;
@@ -27,6 +28,11 @@ public class StoreService {
     private final StoreRepository storeRepository;
     private final CheerRepository cheerRepository;
     private final ImageStorage imageStorage;
+
+    public StoreResponse getStore(long storeId) {
+        Store store = storeRepository.getById(storeId);
+        return new StoreResponse(store);
+    }
 
     // TODO : N+1 문제 해결
     public StoresResponse getStores(int size) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -43,7 +43,7 @@ jwt:
 cors:
   origin:
     - "http://localhost:3000"
-    - "https://api-dev.eatda.net"
+    - "https://dev.eatda.net"
 
 oauth:
   client-id: ${OAUTH_CLIENT_ID}

--- a/src/test/java/eatda/controller/store/StoreControllerTest.java
+++ b/src/test/java/eatda/controller/store/StoreControllerTest.java
@@ -13,6 +13,32 @@ import org.springframework.http.HttpHeaders;
 class StoreControllerTest extends BaseControllerTest {
 
     @Nested
+    class GetStore {
+
+        @Test
+        void 음식점_정보를_조회한다() {
+            Member member = memberGenerator.generate("111");
+            Store store = storeGenerator.generate("농민백암순대", "서울 강남구 대치동 896-33");
+            cheerGenerator.generateCommon(member, store, "image-key");
+
+            StoreResponse response = given()
+                    .pathParam("storeId", store.getId())
+                    .when()
+                    .get("/api/shops/{storeId}")
+                    .then()
+                    .statusCode(200)
+                    .extract().as(StoreResponse.class);
+
+            assertAll(
+                    () -> assertThat(response.id()).isEqualTo(store.getId()),
+                    () -> assertThat(response.name()).isEqualTo(store.getName()),
+                    () -> assertThat(response.district()).isEqualTo("강남구"),
+                    () -> assertThat(response.neighborhood()).isEqualTo("대치동")
+            );
+        }
+    }
+
+    @Nested
     class GetStores {
 
         @Test

--- a/src/test/java/eatda/service/store/StoreServiceTest.java
+++ b/src/test/java/eatda/service/store/StoreServiceTest.java
@@ -2,12 +2,16 @@ package eatda.service.store;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 
 import eatda.client.map.StoreSearchResult;
+import eatda.controller.store.StoreResponse;
 import eatda.domain.member.Member;
 import eatda.domain.store.Store;
+import eatda.exception.BusinessErrorCode;
+import eatda.exception.BusinessException;
 import eatda.service.BaseServiceTest;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
@@ -18,6 +22,36 @@ class StoreServiceTest extends BaseServiceTest {
 
     @Autowired
     private StoreService storeService;
+
+    @Nested
+    class GetStore {
+
+        @Test
+        void 음식점_정보를_조회한다() {
+            Member member = memberGenerator.generate("111");
+            Store store = storeGenerator.generate("농민백암순대", "서울 강남구 대치동 896-33");
+            cheerGenerator.generateCommon(member, store, "image-key");
+
+            StoreResponse response = storeService.getStore(store.getId());
+
+            assertAll(
+                    () -> assertThat(response.id()).isEqualTo(store.getId()),
+                    () -> assertThat(response.name()).isEqualTo(store.getName()),
+                    () -> assertThat(response.district()).isEqualTo("강남구"),
+                    () -> assertThat(response.neighborhood()).isEqualTo("대치동")
+            );
+        }
+
+        @Test
+        void 해당_음식점이_없을_경우_예외를_던진다() {
+            long nonExistentStoreId = 999L;
+
+            BusinessException exception = assertThrows(BusinessException.class,
+                    () -> storeService.getStore(nonExistentStoreId));
+
+            assertThat(exception.getErrorCode()).isEqualTo(BusinessErrorCode.STORE_NOT_FOUND);
+        }
+    }
 
     @Nested
     class GetStores {


### PR DESCRIPTION
## ✨ 개요
- 가게 상세 정보 조회 API 구현
- 자세한 사항은 이슈 참고해주세요!

## 🧾 관련 이슈
closed #97 

## 🔍 참고 사항 (선택)
- 이미지는 다른 API를 통해 제공

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 특정 음식점의 상세 정보를 조회할 수 있는 API 엔드포인트(`/api/shops/{storeId}`)가 추가되었습니다.
  * 음식점 상세 정보 응답에 ID, 카카오ID, 이름, 행정구, 동네, 카테고리, 장소 URL이 포함됩니다.

* **테스트**
  * 음식점 상세 조회 기능에 대한 컨트롤러, 서비스, API 문서 테스트가 추가되었습니다.
  * 음식점이 존재하지 않을 때의 예외 처리 테스트가 포함되었습니다.

* **문서화**
  * 음식점 상세 조회 API에 대한 문서가 추가 및 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->