### PR TITLE
[Feat] 가게 이미지 조회 API 구현

### DIFF
--- a/src/main/java/eatda/controller/store/ImagesResponse.java
+++ b/src/main/java/eatda/controller/store/ImagesResponse.java
@@ -1,0 +1,6 @@
+package eatda.controller.store;
+
+import java.util.List;
+
+public record ImagesResponse(List<String> imageUrls) {
+}

--- a/src/main/java/eatda/controller/store/StoreController.java
+++ b/src/main/java/eatda/controller/store/StoreController.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,6 +16,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class StoreController {
 
     private final StoreService storeService;
+
+    @GetMapping("/api/shops/{storeId}/images")
+    public ResponseEntity<ImagesResponse> getStoreImages(@PathVariable long storeId) {
+        return ResponseEntity.ok(storeService.getStoreImages(storeId));
+    }
 
     @GetMapping("/api/shops")
     public ResponseEntity<StoresResponse> getStores(@RequestParam @Min(1) @Max(50) int size) {

--- a/src/main/java/eatda/repository/store/CheerRepository.java
+++ b/src/main/java/eatda/repository/store/CheerRepository.java
@@ -7,12 +7,10 @@ import eatda.domain.store.Store;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.Repository;
 
-public interface CheerRepository extends Repository<Cheer, Long> {
-
-    Cheer save(Cheer cheer);
+public interface CheerRepository extends JpaRepository<Cheer, Long> {
 
     List<Cheer> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
@@ -22,6 +20,12 @@ public interface CheerRepository extends Repository<Cheer, Long> {
                 ORDER BY c.createdAt DESC
                 LIMIT 1""")
     Optional<ImageKey> findRecentImageKey(Store store);
+
+    @Query("""
+            SELECT c.imageKey FROM Cheer c
+                WHERE c.store = :store AND c.imageKey IS NOT NULL
+                ORDER BY c.createdAt DESC""")
+    List<ImageKey> findAllImageKey(Store store);
 
     int countByMember(Member member);
 

--- a/src/main/java/eatda/repository/store/StoreRepository.java
+++ b/src/main/java/eatda/repository/store/StoreRepository.java
@@ -1,14 +1,20 @@
 package eatda.repository.store;
 
 import eatda.domain.store.Store;
+import eatda.exception.BusinessErrorCode;
+import eatda.exception.BusinessException;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.repository.Repository;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StoreRepository extends Repository<Store, Long> {
+public interface StoreRepository extends JpaRepository<Store, Long> {
 
-    Store save(Store store);
+    @Override
+    default Store getById(Long id) {
+        return findById(id)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.STORE_NOT_FOUND));
+    }
 
     Optional<Store> findByKakaoId(String kakaoId);
 

--- a/src/main/java/eatda/service/store/StoreService.java
+++ b/src/main/java/eatda/service/store/StoreService.java
@@ -5,6 +5,7 @@ import static java.util.stream.Collectors.toList;
 
 import eatda.client.map.MapClient;
 import eatda.client.map.StoreSearchResult;
+import eatda.controller.store.ImagesResponse;
 import eatda.controller.store.StorePreviewResponse;
 import eatda.controller.store.StoreSearchResponses;
 import eatda.controller.store.StoresResponse;
@@ -27,6 +28,15 @@ public class StoreService {
     private final StoreRepository storeRepository;
     private final CheerRepository cheerRepository;
     private final ImageStorage imageStorage;
+
+    public ImagesResponse getStoreImages(long storeId) {
+        Store store = storeRepository.getById(storeId);
+        List<String> imageUrls = cheerRepository.findAllImageKey(store)
+                .stream()
+                .map(imageStorage::getPreSignedUrl)
+                .toList();
+        return new ImagesResponse(imageUrls);
+    }
 
     // TODO : N+1 문제 해결
     public StoresResponse getStores(int size) {

--- a/src/test/java/eatda/controller/store/StoreControllerTest.java
+++ b/src/test/java/eatda/controller/store/StoreControllerTest.java
@@ -13,6 +13,42 @@ import org.springframework.http.HttpHeaders;
 class StoreControllerTest extends BaseControllerTest {
 
     @Nested
+    class GetStoreImages {
+
+        @Test
+        void 음식점_이미지들을_조회한다() {
+            Member member = memberGenerator.generate("111");
+            Store store = storeGenerator.generate("농민백암순대", "서울 강남구 대치동 896-33");
+            cheerGenerator.generateCommon(member, store, "image-key-1");
+            cheerGenerator.generateCommon(member, store, "image-key-2");
+            cheerGenerator.generateCommon(member, store, "image-key-3");
+
+            ImagesResponse response = given()
+                    .when()
+                    .get("/api/shops/{storeId}/images", store.getId())
+                    .then()
+                    .statusCode(200)
+                    .extract().as(ImagesResponse.class);
+
+            assertThat(response.imageUrls()).hasSize(3);
+        }
+
+        @Test
+        void 음식점_이미지가_없다면_빈_리스트를_반환한다() {
+            Store store = storeGenerator.generate("농민백암순대", "서울 강남구 대치동 896-33");
+
+            ImagesResponse response = given()
+                    .when()
+                    .get("/api/shops/{storeId}/images", store.getId())
+                    .then()
+                    .statusCode(200)
+                    .extract().as(ImagesResponse.class);
+
+            assertThat(response.imageUrls()).isEmpty();
+        }
+    }
+
+    @Nested
     class GetStores {
 
         @Test

--- a/src/test/java/eatda/repository/store/CheerRepositoryTest.java
+++ b/src/test/java/eatda/repository/store/CheerRepositoryTest.java
@@ -6,6 +6,7 @@ import eatda.domain.ImageKey;
 import eatda.domain.member.Member;
 import eatda.domain.store.Store;
 import eatda.repository.BaseRepositoryTest;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -26,7 +27,9 @@ class CheerRepositoryTest extends BaseRepositoryTest {
 
             Optional<ImageKey> imageKey = cheerRepository.findRecentImageKey(store);
 
-            assertThat(imageKey).contains(new ImageKey("image-key-2"));
+            assertThat(imageKey)
+                    .map(ImageKey::getValue)
+                    .contains("image-key-2");
         }
 
         @Test
@@ -40,6 +43,39 @@ class CheerRepositoryTest extends BaseRepositoryTest {
             Optional<ImageKey> imageKey = cheerRepository.findRecentImageKey(store);
 
             assertThat(imageKey).isEmpty();
+        }
+    }
+
+    @Nested
+    class FindAllImageKey {
+
+        @Test
+        void 응원들_중_모든_null이_아닌_이미지_키를_조회한다() throws InterruptedException {
+            Member member = memberGenerator.generate("111");
+            Store store = storeGenerator.generate("농민백암순대", "서울 강남구 대치동 896-33");
+            cheerGenerator.generateCommon(member, store, "image-key-1");
+            Thread.sleep(5);
+            cheerGenerator.generateCommon(member, store, "image-key-2");
+            cheerGenerator.generateCommon(member, store, null);
+
+            List<ImageKey> imageKeys = cheerRepository.findAllImageKey(store);
+
+            assertThat(imageKeys)
+                    .extracting(ImageKey::getValue)
+                    .containsExactly("image-key-2", "image-key-1");
+        }
+
+        @Test
+        void 응원들의_이미지가_모두_비어있다면_빈_리스트를_반환한다() {
+            Member member = memberGenerator.generate("111");
+            Store store = storeGenerator.generate("농민백암순대", "서울 강남구 대치동 896-33");
+            cheerGenerator.generateCommon(member, store, null);
+            cheerGenerator.generateCommon(member, store, null);
+            cheerGenerator.generateCommon(member, store, null);
+
+            List<ImageKey> imageKeys = cheerRepository.findAllImageKey(store);
+
+            assertThat(imageKeys).isEmpty();
         }
     }
 }

--- a/src/test/java/eatda/service/store/StoreServiceTest.java
+++ b/src/test/java/eatda/service/store/StoreServiceTest.java
@@ -2,12 +2,16 @@ package eatda.service.store;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 
 import eatda.client.map.StoreSearchResult;
+import eatda.controller.store.ImagesResponse;
 import eatda.domain.member.Member;
 import eatda.domain.store.Store;
+import eatda.exception.BusinessErrorCode;
+import eatda.exception.BusinessException;
 import eatda.service.BaseServiceTest;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
@@ -18,6 +22,42 @@ class StoreServiceTest extends BaseServiceTest {
 
     @Autowired
     private StoreService storeService;
+
+    @Nested
+    class GetStoreImages {
+
+        @Test
+        void 음식점_이미지들을_조회한다() {
+            Member member = memberGenerator.generate("111");
+            Store store = storeGenerator.generate("농민백암순대", "서울 강남구 대치동 896-33");
+            cheerGenerator.generateCommon(member, store, "image-key-1");
+            cheerGenerator.generateCommon(member, store, "image-key-2");
+            cheerGenerator.generateCommon(member, store, "image-key-3");
+
+            ImagesResponse response = storeService.getStoreImages(store.getId());
+
+            assertThat(response.imageUrls()).hasSize(3);
+        }
+
+        @Test
+        void 음식점_이미지가_없다면_빈_리스트를_반환한다() {
+            Store store = storeGenerator.generate("농민백암순대", "서울 강남구 대치동 896-33");
+
+            ImagesResponse response = storeService.getStoreImages(store.getId());
+
+            assertThat(response.imageUrls()).isEmpty();
+        }
+
+        @Test
+        void 음식점이_존재하지_않으면_예외를_발생시킨다() {
+            long nonExistentStoreId = 999L;
+
+            BusinessException exception = assertThrows(BusinessException.class,
+                    () -> storeService.getStoreImages(nonExistentStoreId));
+
+            assertThat(exception.getErrorCode()).isEqualTo(BusinessErrorCode.STORE_NOT_FOUND);
+        }
+    }
 
     @Nested
     class GetStores {


### PR DESCRIPTION
## ✨ 개요
- 가게 상세 페이지에서 사용할 '가게 이미지 조회 API' 구현
- 자세한 사항은 관련 이슈 참고 부탁드립니다!

## 🧾 관련 이슈
closed #98 

## 🔍 참고 사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 음식점의 이미지 URL 목록을 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 음식점이 존재하지 않을 경우 적절한 오류 응답을 반환하도록 개선되었습니다.

* **테스트**
  * 음식점 이미지 조회 API 및 서비스에 대한 단위 테스트와 문서화 테스트가 추가되었습니다.
  * 이미지 키 조회 관련 저장소 테스트가 보강되었습니다.

* **문서화**
  * 음식점 이미지 조회 API에 대한 REST Docs 문서가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->