### PR TITLE
[Test] 생성 시각에 의한 테스트 개선

### DIFF
--- a/src/main/java/eatda/domain/AuditingEntity.java
+++ b/src/main/java/eatda/domain/AuditingEntity.java
@@ -15,6 +15,8 @@ public abstract class AuditingEntity {
 
     @PrePersist
     protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
+        if (createdAt == null) {
+            this.createdAt = LocalDateTime.now();
+        }
     }
 }

--- a/src/test/java/eatda/controller/article/ArticleControllerTest.java
+++ b/src/test/java/eatda/controller/article/ArticleControllerTest.java
@@ -3,7 +3,7 @@ package eatda.controller.article;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import eatda.controller.BaseControllerTest;
-import eatda.domain.article.Article;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -14,8 +14,9 @@ public class ArticleControllerTest extends BaseControllerTest {
 
         @Test
         void 가게의_담긴_이야기_목록을_조회할_수_있다() {
-            Article article1 = articleGenerator.generate("국밥의 모든 것");
-            Article article2 = articleGenerator.generate("순대국의 진실");
+            LocalDateTime startAt = LocalDateTime.of(2023, 10, 1, 0, 0);
+            articleGenerator.generate("국밥의 모든 것", startAt);
+            articleGenerator.generate("순대국의 진실", startAt.plusHours(1));
 
             ArticlesResponse response = given()
                     .queryParam("size", 3)

--- a/src/test/java/eatda/controller/store/CheerControllerTest.java
+++ b/src/test/java/eatda/controller/store/CheerControllerTest.java
@@ -9,6 +9,7 @@ import eatda.domain.store.Cheer;
 import eatda.domain.store.Store;
 import eatda.util.ImageUtils;
 import eatda.util.MappingUtils;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
@@ -64,9 +65,10 @@ class CheerControllerTest extends BaseControllerTest {
             Member member = memberGenerator.generateRegisteredMember("nickname", "ac@kakao.com", "123", "01011111111");
             Store store1 = storeGenerator.generate("111", "서울시 노원구 월계3동 123-45");
             Store store2 = storeGenerator.generate("222", "서울시 성북구 석관동 123-45");
-            Cheer cheer1 = cheerGenerator.generateAdmin(member, store1);
-            Cheer cheer2 = cheerGenerator.generateAdmin(member, store1);
-            Cheer cheer3 = cheerGenerator.generateAdmin(member, store2);
+            LocalDateTime startAt = LocalDateTime.of(2025, 7, 26, 1, 0, 0);
+            Cheer cheer1 = cheerGenerator.generateAdmin(member, store1, startAt);
+            Cheer cheer2 = cheerGenerator.generateAdmin(member, store1, startAt.plusHours(1));
+            Cheer cheer3 = cheerGenerator.generateAdmin(member, store2, startAt.plusHours(2));
 
             CheersResponse response = given()
                     .when()

--- a/src/test/java/eatda/controller/store/StoreControllerTest.java
+++ b/src/test/java/eatda/controller/store/StoreControllerTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import eatda.controller.BaseControllerTest;
 import eatda.domain.member.Member;
 import eatda.domain.store.Store;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
@@ -18,9 +19,10 @@ class StoreControllerTest extends BaseControllerTest {
         @Test
         void 음식점_목록을_최신순으로_조회한다() {
             Member member = memberGenerator.generate("111");
-            Store store1 = storeGenerator.generate("111", "서울 강남구 대치동 896-33");
-            Store store2 = storeGenerator.generate("222", "서울 강남구 대치동 896-34");
-            Store store3 = storeGenerator.generate("333", "서울 강남구 대치동 896-35");
+            LocalDateTime startAt = LocalDateTime.of(2025, 7, 26, 1, 0, 0);
+            Store store1 = storeGenerator.generate("111", "서울 강남구 대치동 896-33", startAt);
+            Store store2 = storeGenerator.generate("222", "서울 강남구 대치동 896-34", startAt.plusHours(1));
+            Store store3 = storeGenerator.generate("333", "서울 강남구 대치동 896-35", startAt.plusHours(2));
             cheerGenerator.generateCommon(member, store1, "image-key-1");
             cheerGenerator.generateCommon(member, store2, "image-key-2");
             cheerGenerator.generateCommon(member, store3, "image-key-3");

--- a/src/test/java/eatda/fixture/ArticleGenerator.java
+++ b/src/test/java/eatda/fixture/ArticleGenerator.java
@@ -3,6 +3,8 @@ package eatda.fixture;
 import eatda.domain.ImageKey;
 import eatda.domain.article.Article;
 import eatda.repository.article.ArticleRepository;
+import eatda.util.DomainUtils;
+import java.time.LocalDateTime;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -25,6 +27,12 @@ public class ArticleGenerator {
 
     public Article generate(String title) {
         return generate(title, DEFAULT_SUBTITLE);
+    }
+
+    public Article generate(String title, LocalDateTime createdAt) {
+        Article article = generate(title, DEFAULT_SUBTITLE);
+        DomainUtils.setCreatedAt(article, createdAt);
+        return articleRepository.save(article);
     }
 
     public Article generate(String title, String subtitle) {

--- a/src/test/java/eatda/fixture/CheerGenerator.java
+++ b/src/test/java/eatda/fixture/CheerGenerator.java
@@ -5,6 +5,8 @@ import eatda.domain.member.Member;
 import eatda.domain.store.Cheer;
 import eatda.domain.store.Store;
 import eatda.repository.store.CheerRepository;
+import eatda.util.DomainUtils;
+import java.time.LocalDateTime;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -19,8 +21,9 @@ public class CheerGenerator {
         this.cheerRepository = cheerRepository;
     }
 
-    public Cheer generateAdmin(Member member, Store store) {
+    public Cheer generateAdmin(Member member, Store store, LocalDateTime createdAt) {
         Cheer cheer = new Cheer(member, store, DEFAULT_DESCRIPTION, new ImageKey(DEFAULT_IMAGE_KEY), true);
+        DomainUtils.setCreatedAt(cheer, createdAt);
         return cheerRepository.save(cheer);
     }
 

--- a/src/test/java/eatda/fixture/StoreGenerator.java
+++ b/src/test/java/eatda/fixture/StoreGenerator.java
@@ -3,6 +3,8 @@ package eatda.fixture;
 import eatda.domain.store.Store;
 import eatda.domain.store.StoreCategory;
 import eatda.repository.store.StoreRepository;
+import eatda.util.DomainUtils;
+import java.time.LocalDateTime;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -35,6 +37,12 @@ public class StoreGenerator {
                 .latitude(DEFAULT_LATITUDE)
                 .longitude(DEFAULT_LONGITUDE)
                 .build();
+        return storeRepository.save(store);
+    }
+
+    public Store generate(String kakaoId, String lotNumberAddress, LocalDateTime createdAt) {
+        Store store = generate(kakaoId, lotNumberAddress);
+        DomainUtils.setCreatedAt(store, createdAt);
         return storeRepository.save(store);
     }
 }

--- a/src/test/java/eatda/service/article/ArticleServiceTest.java
+++ b/src/test/java/eatda/service/article/ArticleServiceTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import eatda.controller.article.ArticleResponse;
 import eatda.service.BaseServiceTest;
-import java.util.stream.LongStream;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,8 +19,12 @@ public class ArticleServiceTest extends BaseServiceTest {
 
         @Test
         void 가게의_담긴_이야기를_최신순으로_조회할_수_있다() {
-            LongStream.rangeClosed(1, 5)
-                    .forEach(i -> articleGenerator.generate("아티클 제목 " + i));
+            LocalDateTime startAt = LocalDateTime.of(2025, 7, 26, 12, 0, 0);
+            articleGenerator.generate("아티클 제목 1", startAt);
+            articleGenerator.generate("아티클 제목 2", startAt.plusHours(1));
+            articleGenerator.generate("아티클 제목 3", startAt.plusHours(2));
+            articleGenerator.generate("아티클 제목 4", startAt.plusHours(3));
+            articleGenerator.generate("아티클 제목 5", startAt.plusHours(4));
 
             var response = articleService.getAllArticles(3);
 

--- a/src/test/java/eatda/service/store/CheerServiceTest.java
+++ b/src/test/java/eatda/service/store/CheerServiceTest.java
@@ -16,6 +16,7 @@ import eatda.domain.store.Store;
 import eatda.exception.BusinessErrorCode;
 import eatda.exception.BusinessException;
 import eatda.service.BaseServiceTest;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -134,9 +135,10 @@ class CheerServiceTest extends BaseServiceTest {
             Member member = memberGenerator.generate("123");
             Store store1 = storeGenerator.generate("123", "서울시 강남구 역삼동 123-45");
             Store store2 = storeGenerator.generate("456", "서울시 성북구 석관동 123-45");
-            Cheer cheer1 = cheerGenerator.generateAdmin(member, store1);
-            Cheer cheer2 = cheerGenerator.generateAdmin(member, store1);
-            Cheer cheer3 = cheerGenerator.generateAdmin(member, store2);
+            LocalDateTime startAt = LocalDateTime.of(2025, 7, 26, 1, 0, 0);
+            Cheer cheer1 = cheerGenerator.generateAdmin(member, store1, startAt);
+            Cheer cheer2 = cheerGenerator.generateAdmin(member, store1, startAt.plusHours(1));
+            Cheer cheer3 = cheerGenerator.generateAdmin(member, store2, startAt.plusHours(2));
 
             CheersResponse response = cheerService.getCheers(2);
 

--- a/src/test/java/eatda/service/store/StoreServiceTest.java
+++ b/src/test/java/eatda/service/store/StoreServiceTest.java
@@ -9,6 +9,7 @@ import eatda.client.map.StoreSearchResult;
 import eatda.domain.member.Member;
 import eatda.domain.store.Store;
 import eatda.service.BaseServiceTest;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -25,11 +26,12 @@ class StoreServiceTest extends BaseServiceTest {
         @Test
         void 음식점_목록을_최신순으로_조회한다() {
             Member member = memberGenerator.generate("111");
-            Store store1 = storeGenerator.generate("농민백암순대", "서울 강남구 대치동 896-33");
+            LocalDateTime startAt = LocalDateTime.of(2025, 7, 26, 1, 0, 0);
+            Store store1 = storeGenerator.generate("농민백암순대", "서울 강남구 대치동 896-33", startAt);
+            Store store2 = storeGenerator.generate("석관동떡볶이", "서울 성북구 석관동 123-45", startAt.plusHours(1));
+            Store store3 = storeGenerator.generate("강남순대국", "서울 강남구 역삼동 678-90", startAt.plusHours(2));
             cheerGenerator.generateCommon(member, store1, "image-key-1");
-            Store store2 = storeGenerator.generate("석관동떡볶이", "서울 성북구 석관동 123-45");
             cheerGenerator.generateCommon(member, store2, "image-key-2");
-            Store store3 = storeGenerator.generate("강남순대국", "서울 강남구 역삼동 678-90");
             cheerGenerator.generateCommon(member, store3, "image-key-3");
 
             int size = 2;

--- a/src/test/java/eatda/util/DomainUtils.java
+++ b/src/test/java/eatda/util/DomainUtils.java
@@ -1,0 +1,21 @@
+package eatda.util;
+
+import eatda.domain.AuditingEntity;
+import java.time.LocalDateTime;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public final class DomainUtils {
+
+    private static final String CREATED_AT_FIELD = "createdAt";
+
+    private DomainUtils() {
+    }
+
+    public static <T extends AuditingEntity> void setCreatedAt(T entity, LocalDateTime createdAt) {
+        try {
+            ReflectionTestUtils.setField(entity, CREATED_AT_FIELD, createdAt);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to set createdAt field", e);
+        }
+    }
+}


### PR DESCRIPTION
## ✨ 개요
- 테스트 시 순차적으로 생성되지만, 간혹 같은 시각에 생성되는 객체가 존재하여 테스트가 실패함
- createdAt을 Reflextion으로 지정하여 생성 시각을 지정하도록 함

## 🧾 관련 이슈
없음

## 🔍 참고 사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 생성 일시(createdAt)가 이미 설정된 경우, 기존 값을 보존하도록 개선되어 불필요하게 덮어쓰지 않도록 수정되었습니다.

* **테스트**
  * 테스트 데이터(가게, 응원, 아티클 등)에 명시적인 생성 일시를 부여하여, 시간 순서에 따른 정렬 및 반환 결과를 더 명확하게 검증합니다.
  * 테스트용 유틸리티와 생성기(Generator)에 생성 일시를 지정할 수 있는 기능이 추가되었습니다.
  * 새로운 테스트 유틸리티 클래스가 도입되어 테스트 엔티티의 생성 일시를 손쉽게 설정할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->