### PR TITLE
[Fix] 스토리 상세 조회 API에 회원 정보 추가

### DIFF
--- a/src/main/java/eatda/controller/story/StoryResponse.java
+++ b/src/main/java/eatda/controller/story/StoryResponse.java
@@ -7,6 +7,8 @@ public record StoryResponse(
         String storeDistrict,
         String storeNeighborhood,
         String description,
-        String imageUrl
+        String imageUrl,
+        long memberId,
+        String memberNickname
 ) {
 }

--- a/src/main/java/eatda/service/story/StoryService.java
+++ b/src/main/java/eatda/service/story/StoryService.java
@@ -101,7 +101,9 @@ public class StoryService {
                 story.getAddressDistrict(),
                 story.getAddressNeighborhood(),
                 story.getDescription(),
-                imageStorage.getPreSignedUrl(story.getImageKey())
+                imageStorage.getPreSignedUrl(story.getImageKey()),
+                story.getMember().getId(),
+                story.getMember().getNickname()
         );
     }
 }

--- a/src/test/java/eatda/controller/story/StoryControllerTest.java
+++ b/src/test/java/eatda/controller/story/StoryControllerTest.java
@@ -96,7 +96,9 @@ public class StoryControllerTest extends BaseControllerTest {
                     "성동구",
                     "성수동",
                     "곱창은 여기",
-                    "https://s3.bucket.com/story1.jpg"
+                    "https://s3.bucket.com/story1.jpg",
+                    1L,
+                    "커찬"
             )).when(storyService).getStory(storyId);
 
             StoryResponse response = given()
@@ -114,7 +116,9 @@ public class StoryControllerTest extends BaseControllerTest {
                     () -> assertThat(response.storeDistrict()).isEqualTo("성동구"),
                     () -> assertThat(response.storeNeighborhood()).isEqualTo("성수동"),
                     () -> assertThat(response.description()).isEqualTo("곱창은 여기"),
-                    () -> assertThat(response.imageUrl()).isEqualTo("https://s3.bucket.com/story1.jpg")
+                    () -> assertThat(response.imageUrl()).isEqualTo("https://s3.bucket.com/story1.jpg"),
+                    () -> assertThat(response.memberId()).isEqualTo(1L),
+                    () -> assertThat(response.memberNickname()).isEqualTo("커찬")
             );
         }
 

--- a/src/test/java/eatda/document/story/StoryDocumentTest.java
+++ b/src/test/java/eatda/document/story/StoryDocumentTest.java
@@ -164,7 +164,9 @@ public class StoryDocumentTest extends BaseDocumentTest {
                         fieldWithPath("storeDistrict").description("가게 주소의 구"),
                         fieldWithPath("storeNeighborhood").description("가게 주소의 동"),
                         fieldWithPath("description").description("스토리 내용"),
-                        fieldWithPath("imageUrl").description("스토리 이미지 URL")
+                        fieldWithPath("imageUrl").description("스토리 이미지 URL"),
+                        fieldWithPath("memberId").description("회원 ID"),
+                        fieldWithPath("memberNickname").description("회원 닉네임")
                 );
 
         @Test
@@ -177,7 +179,9 @@ public class StoryDocumentTest extends BaseDocumentTest {
                     "성동구",
                     "성수동",
                     "곱창은 여기",
-                    "https://s3.bucket.com/story1.jpg"
+                    "https://s3.bucket.com/story1.jpg",
+                    1L,
+                    "커찬"
             );
             doReturn(response).when(storyService).getStory(storyId);
 


### PR DESCRIPTION
## ✨ 개요
- 스토리 상세 조회 API에 회원 정보 추가

## 🧾 관련 이슈
closed #121 

## 🔍 참고 사항 (선택)
DEV 톡방 참고해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 스토리 상세 조회 시 응답에 회원 ID와 닉네임 정보가 추가되었습니다.

* **테스트**
  * 스토리 상세 조회 API 테스트 및 문서화에 회원 ID와 닉네임 필드에 대한 검증이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->