### PR TITLE
[Fix] '카페' 카테고리를 '카페/디저트'로 보이도록 수정

### DIFF
--- a/src/main/java/eatda/domain/store/StoreCategory.java
+++ b/src/main/java/eatda/domain/store/StoreCategory.java
@@ -12,7 +12,7 @@ public enum StoreCategory {
     CHINESE("중식"),
     JAPANESE("일식"),
     WESTERN("양식"),
-    CAFE("카페"),
+    CAFE("카페/디저트"),
     OTHER("기타");
 
     private final String categoryName;


### PR DESCRIPTION
## ✨ 개요
- FE 화면에서 보이는 '카페' 카테고리를 '카페/디저트'로 보이도록 수정

## 🧾 관련 이슈
없음

## 🔍 참고 사항 (선택)
AS-IS
카테고리
KOREAN("한식")
CHINESE("중식")
JAPANESE("일식")
WESTERN("양식")
CAFE("카페") 
DESSERT("디저트")
PUB("술집")
FAST_FOOD("패스트푸드")
CONVENIENCE("편의점")
OTHER("기타")

TO-BE
KOREAN("한식")
CHINESE("중식")
JAPANESE("일식")
WESTERN("양식")
**CAFE("카페/디저트")**  - 디저트를 cafe로 편입시킨다. (**화면에 노출되는 라이팅 : 카페/디저트**)
OTHER("기타") - 술집, 패스트푸드, 편의점, 기타를 모두 기타로 편입한다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 카테고리 "카페"의 표시명이 "카페/디저트"로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->