### PR TITLE
[Feat] 어플리케이션 로그 파일 백업

### DIFF
--- a/terraform/dev/locals.tf
+++ b/terraform/dev/locals.tf
@@ -46,15 +46,9 @@ locals {
     role                 = "dev"
     iam_instance_profile = data.terraform_remote_state.common.outputs.instance_profile_name["ec2-to-ecs"]
     key_name             = "eatda-ec2-dev-key"
-    user_data            = <<-EOF
-#!/bin/bash
-echo ECS_CLUSTER=dev-cluster >> /etc/ecs/ecs.config
-fallocate -l 2G /swapfile
-chmod 600 /swapfile
-mkswap /swapfile
-swapon /swapfile
-echo '/swapfile none swap sw 0 0' >> /etc/fstab
-EOF
+    user_data = templatefile("${path.module}/scripts/user-data.sh", {
+      ecs_cluster_name = "dev-cluster"
+    })
   }
 
   task_definitions_with_roles = {

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -5,6 +5,7 @@ module "ec2" {
   instance_subnet_map  = local.instance_subnet_map
   name_prefix          = local.name_prefix
   tags                 = local.common_tags
+  depends_on = [module.s3]
 }
 
 module "ecs" {

--- a/terraform/dev/s3/main.tf
+++ b/terraform/dev/s3/main.tf
@@ -8,6 +8,14 @@ resource "aws_s3_bucket" "dev" {
   }
 }
 
+resource "aws_s3_object" "app-backup-log-script" {
+  bucket       = aws_s3_bucket.dev.bucket
+  key          = "scripts/app-backup-dev-logs.sh"
+  source       = "${path.module}/scripts/app-backup-dev-logs.sh"
+  etag = filemd5("${path.module}/scripts/app-backup-dev-logs.sh")
+  content_type = "text/x-sh"
+}
+
 resource "aws_s3_bucket_public_access_block" "dev" {
   bucket = aws_s3_bucket.dev.id
 

--- a/terraform/dev/s3/scripts/app-backup-dev-logs.sh
+++ b/terraform/dev/s3/scripts/app-backup-dev-logs.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+LOG_DIR="/home/ec2-user/logs/eatda"
+S3_BUCKET="s3://eatda-storage-dev/backup/logs/"
+TIMESTAMP=$(date +%Y-%m-%d-%H%M%S)
+ARCHIVE_PATH="/tmp/eatda-logs-${TIMESTAMP}.tar.gz"
+
+if [ ! -d "$LOG_DIR" ]; then
+  echo "[ERROR] Log directory does not exist: $LOG_DIR" >&2
+  exit 1
+fi
+
+tar -czf "$ARCHIVE_PATH" -C "$LOG_DIR" .
+
+if aws s3 cp "$ARCHIVE_PATH" "$S3_BUCKET"; then
+  echo "[INFO] Upload successful: $ARCHIVE_PATH -> $S3_BUCKET"
+
+  find "$LOG_DIR" -type f -name "*.log" -delete
+  echo "[INFO] Old log files deleted from $LOG_DIR"
+
+  rm "$ARCHIVE_PATH"
+else
+  echo "[ERROR] Failed to upload archive to S3." >&2
+  exit 1
+fi

--- a/terraform/dev/scripts/user-data.sh
+++ b/terraform/dev/scripts/user-data.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+echo ECS_CLUSTER=${ecs_cluster_name} >> /etc/ecs/ecs.config
+
+fallocate -l 2G /swapfile
+chmod 600 /swapfile
+mkswap /swapfile
+swapon /swapfile
+echo '/swapfile none swap sw 0 0' >> /etc/fstab
+
+/bin/mkdir -p /home/ec2-user/logs/eatda
+
+aws s3 cp s3://eatda-storage-dev/scripts/app-backup-dev-logs.sh /home/ec2-user/logs/eatda/app-backup-dev-logs.sh
+chmod +x /home/ec2-user/logs/eatda/app-backup-dev-logs.sh
+
+(crontab -l 2>/dev/null; echo "0 0 * * 0 /home/ec2-user/logs/eatda/app-backup-dev-logs.sh >> /var/log/app-backup.log 2>&1") | crontab -

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -15,6 +15,7 @@ module "ec2" {
   instance_subnet_map  = local.instance_subnet_map
   name_prefix          = local.name_prefix
   tags                 = local.common_tags
+  depends_on = [module.s3]
 }
 
 module "ecs" {

--- a/terraform/prod/s3/main.tf
+++ b/terraform/prod/s3/main.tf
@@ -8,6 +8,14 @@ resource "aws_s3_bucket" "prod" {
   }
 }
 
+resource "aws_s3_object" "app-backup-log-script" {
+  bucket       = aws_s3_bucket.prod.bucket
+  key          = "scripts/app-backup-prod-logs.sh"
+  source       = "${path.module}/scripts/app-backup-prod-logs.sh"
+  etag = filemd5("${path.module}/scripts/app-backup-prod-logs.sh")
+  content_type = "text/x-sh"
+}
+
 resource "aws_s3_bucket_public_access_block" "prod" {
   bucket = aws_s3_bucket.prod.id
 

--- a/terraform/prod/s3/scripts/app-backup-prod-logs.sh
+++ b/terraform/prod/s3/scripts/app-backup-prod-logs.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+LOG_DIR="/home/ec2-user/logs/eatda"
+S3_BUCKET="s3://eatda-storage-prod/backup/logs/"
+TIMESTAMP=$(date +%Y-%m-%d-%H%M%S)
+ARCHIVE_PATH="/tmp/eatda-logs-${TIMESTAMP}.tar.gz"
+
+if [ ! -d "$LOG_DIR" ]; then
+  echo "[ERROR] Log directory does not exist: $LOG_DIR" >&2
+  exit 1
+fi
+
+tar -czf "$ARCHIVE_PATH" -C "$LOG_DIR" .
+
+if aws s3 cp "$ARCHIVE_PATH" "$S3_BUCKET"; then
+  echo "[INFO] Upload successful: $ARCHIVE_PATH -> $S3_BUCKET"
+
+  find "$LOG_DIR" -type f -name "*.log" -delete
+  echo "[INFO] Old log files deleted from $LOG_DIR"
+
+  rm "$ARCHIVE_PATH"
+else
+  echo "[ERROR] Failed to upload archive to S3." >&2
+  exit 1
+fi

--- a/terraform/prod/scripts/user-data.sh
+++ b/terraform/prod/scripts/user-data.sh
@@ -12,4 +12,4 @@ echo '/swapfile none swap sw 0 0' >> /etc/fstab
 aws s3 cp s3://eatda-storage-prod/scripts/app-backup-prod-logs.sh /home/ec2-user/logs/eatda/app-backup-prod-logs.sh
 chmod +x /home/ec2-user/logs/eatda/app-backup-prod-logs.sh
 
-(crontab -l 2>/prod/null; echo "0 0 * * 0 /home/ec2-user/logs/eatda/app-backup-prod-logs.sh >> /var/log/app-backup.log 2>&1") | crontab -
+(crontab -l 2>/dev/null; echo "0 0 * * 0 /home/ec2-user/logs/eatda/app-backup-prod-logs.sh >> /var/log/app-backup.log 2>&1") | crontab -

--- a/terraform/prod/scripts/user-data.sh
+++ b/terraform/prod/scripts/user-data.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+echo ECS_CLUSTER=${ecs_cluster_name} >> /etc/ecs/ecs.config
+
+fallocate -l 2G /swapfile
+chmod 600 /swapfile
+mkswap /swapfile
+swapon /swapfile
+echo '/swapfile none swap sw 0 0' >> /etc/fstab
+
+/bin/mkdir -p /home/ec2-user/logs/eatda
+
+aws s3 cp s3://eatda-storage-prod/scripts/app-backup-prod-logs.sh /home/ec2-user/logs/eatda/app-backup-prod-logs.sh
+chmod +x /home/ec2-user/logs/eatda/app-backup-prod-logs.sh
+
+(crontab -l 2>/prod/null; echo "0 0 * * 0 /home/ec2-user/logs/eatda/app-backup-prod-logs.sh >> /var/log/app-backup.log 2>&1") | crontab -


### PR DESCRIPTION
## ✨ 개요
- logback으로 생성되는 로그 파일을 주기적으로 S3에 백업하는 쉘 스크립트를 작성하였습니다.
- EC2 인스턴스의 user data를 별도 스크립트 파일로 템플릿화하고,
- 해당 스크립트에서 S3로부터 백업 스크립트를 다운로드한 후 cron에 등록하는 로직을 추가했습니다.
- 백업 주기는 매주 일요일 자정이며, S3 업로드 성공 시 기존 로그 파일은 EBS에서 자동 삭제됩니다.
- aws_s3_object 리소스를 추가하여 Terraform이 백업 스크립트도 S3에 자동 업로드하도록 구성했습니다.
- EC2 인스턴스가 부팅될 때 S3에서 스크립트를 정상적으로 다운로드할 수 있도록
- EC2보다 S3 리소스가 먼저 생성되도록 의존성을 명시했습니다.

## 🧾 관련 이슈
#135 

## 🔍 참고 사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 개발 및 운영 환경에서 로그 백업 자동화 스크립트가 추가되어, 로그 파일을 S3 버킷으로 주기적으로 백업할 수 있습니다.
  * EC2 인스턴스 초기화 시, ECS 클러스터 설정과 2GB 스왑 파일 생성, 로그 디렉터리 및 백업 스크립트 다운로드, 주간 크론 작업 등록이 자동으로 수행됩니다.

* **기타 변경**
  * EC2 리소스가 S3 리소스 생성 이후에 배포되도록 의존성이 명확히 지정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->