### PR TITLE
[Test] StoryControllerTest 가 Mock을 쓰지 않도록 개선

### DIFF
--- a/src/test/java/eatda/controller/BaseControllerTest.java
+++ b/src/test/java/eatda/controller/BaseControllerTest.java
@@ -17,10 +17,12 @@ import eatda.fixture.ArticleGenerator;
 import eatda.fixture.CheerGenerator;
 import eatda.fixture.MemberGenerator;
 import eatda.fixture.StoreGenerator;
+import eatda.fixture.StoryGenerator;
+import eatda.repository.article.ArticleRepository;
 import eatda.repository.member.MemberRepository;
 import eatda.repository.store.CheerRepository;
 import eatda.repository.store.StoreRepository;
-import eatda.service.story.StoryService;
+import eatda.repository.story.StoryRepository;
 import eatda.storage.image.ImageStorage;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
@@ -64,6 +66,9 @@ public class BaseControllerTest {
     protected ArticleGenerator articleGenerator;
 
     @Autowired
+    protected StoryGenerator storyGenerator;
+
+    @Autowired
     protected MemberRepository memberRepository;
 
     @Autowired
@@ -71,6 +76,12 @@ public class BaseControllerTest {
 
     @Autowired
     protected CheerRepository cheerRepository;
+
+    @Autowired
+    protected ArticleRepository articleRepository;
+
+    @Autowired
+    protected StoryRepository storyRepository;
 
     @Autowired
     protected JwtManager jwtManager;
@@ -83,9 +94,6 @@ public class BaseControllerTest {
 
     @MockitoBean
     private ImageStorage imageStorage;
-
-    @MockitoBean
-    protected StoryService storyService; // TODO 실 객체로 변환
 
     @LocalServerPort
     private int port;

--- a/src/test/java/eatda/fixture/StoryGenerator.java
+++ b/src/test/java/eatda/fixture/StoryGenerator.java
@@ -1,0 +1,56 @@
+package eatda.fixture;
+
+import eatda.domain.ImageKey;
+import eatda.domain.member.Member;
+import eatda.domain.store.StoreCategory;
+import eatda.domain.story.Story;
+import eatda.repository.story.StoryRepository;
+import eatda.util.DomainUtils;
+import java.time.LocalDateTime;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StoryGenerator {
+
+    private static final StoreCategory DEFAULT_CATEGORY = StoreCategory.OTHER;
+    private static final String DEFAULT_DESCRIPTION = "이곳은 정말 맛있어요!";
+    private static final String DEFAULT_ROAD_ADDRESS = "서울시 강남구 준비로 11길 123";
+    private static final String DEFAULT_LOT_NUMBER_ADDRESS = "서울시 강남구 역삼동 123-45";
+    private static final ImageKey DEFAULT_IMAGE_KEY = new ImageKey("default-story-image.jpg");
+
+    private final StoryRepository storyRepository;
+
+    public StoryGenerator(StoryRepository storyRepository) {
+        this.storyRepository = storyRepository;
+    }
+
+    public Story generate(Member member, String kakaoId, String storeName) {
+        Story story = create(member, kakaoId, storeName, DEFAULT_LOT_NUMBER_ADDRESS, DEFAULT_DESCRIPTION);
+        return storyRepository.save(story);
+    }
+
+    public Story generate(Member member, String kakaoId, String storeName, LocalDateTime createdAt) {
+        Story story = create(member, kakaoId, storeName, DEFAULT_LOT_NUMBER_ADDRESS, DEFAULT_DESCRIPTION);
+        DomainUtils.setCreatedAt(story, createdAt);
+        return storyRepository.save(story);
+    }
+
+    public Story generate(Member member, String kakaoId, String storeName, String lotNumberAddress,
+                          String description) {
+        Story story = create(member, kakaoId, storeName, lotNumberAddress, description);
+        return storyRepository.save(story);
+    }
+
+    private Story create(Member member, String kakaoId, String storeName, String lotNumberAddress, String description) {
+        return Story.builder()
+                .member(member)
+                .storeKakaoId(kakaoId)
+                .storeCategory(DEFAULT_CATEGORY)
+                .storeName(storeName)
+                .storeRoadAddress(DEFAULT_ROAD_ADDRESS)
+                .storeLotNumberAddress(lotNumberAddress)
+                .description(description)
+                .imageKey(DEFAULT_IMAGE_KEY)
+                .build();
+    }
+}


### PR DESCRIPTION
## ✨ 개요
- AS-IS : StoryController가 MockService를 이용하여 테스트
- TO-BE : StoryController가 실 서비스 객체, 실 레포지토리 객체를 이용하여 테스트하도록 수정

## 🧾 관련 이슈

## 🔍 참고 사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * Story 관련 테스트에서 모킹 대신 실제 데이터 생성 및 저장 방식을 사용하도록 변경되었습니다.
  * Story 엔티티 생성을 위한 StoryGenerator 유틸리티가 추가되었습니다.
  * StoryController 테스트가 서비스 레이어 모킹 없이 통합 테스트 스타일로 리팩터링되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->