### PR TITLE
[Docs] API 명세서 표기 수정

### DIFF
--- a/src/test/java/eatda/document/Tag.java
+++ b/src/test/java/eatda/document/Tag.java
@@ -5,8 +5,8 @@ public enum Tag {
     AUTH_API("Auth API"),
     MEMBER_API("Member API"),
     STORE_API("Store API"),
-    STORY_API("Story API"),
     CHEER_API("Cheer API"),
+    STORY_API("Story API"),
     ARTICLE_API("Article API"),
     ;
 

--- a/src/test/java/eatda/document/store/CheerDocumentTest.java
+++ b/src/test/java/eatda/document/store/CheerDocumentTest.java
@@ -57,7 +57,7 @@ public class CheerDocumentTest extends BaseDocumentTest {
                 """;
 
         RestDocsRequest requestDocument = request()
-                .tag(Tag.STORE_API)
+                .tag(Tag.CHEER_API)
                 .summary("응원 등록")
                 .description(REQUEST_DESCRIPTION_MARKDOWN)
                 .requestHeader(
@@ -133,7 +133,7 @@ public class CheerDocumentTest extends BaseDocumentTest {
     class GetCheers {
 
         RestDocsRequest requestDocument = request()
-                .tag(Tag.STORE_API)
+                .tag(Tag.CHEER_API)
                 .summary("최신 응원 검색")
                 .queryParameter(
                         parameterWithName("size").description("조회 개수 (최소 1, 최대 50)")
@@ -198,7 +198,7 @@ public class CheerDocumentTest extends BaseDocumentTest {
     class GetCheersByStoreId {
 
         RestDocsRequest requestDocument = request()
-                .tag(Tag.STORE_API)
+                .tag(Tag.CHEER_API)
                 .summary("가게별 응원 검색")
                 .pathParameter(
                         parameterWithName("storeId").description("가게 ID")

--- a/src/test/java/eatda/document/story/StoryDocumentTest.java
+++ b/src/test/java/eatda/document/story/StoryDocumentTest.java
@@ -44,8 +44,8 @@ public class StoryDocumentTest extends BaseDocumentTest {
         private static final String REQUEST_DESCRIPTION_MARKDOWN = """
                 - 요청 형식 : multipart/form-data
                 - 요청 field
-                  - `image` : 스토리 이미지 (필수, 최대 5MB, 허용 타입 : image/jpg, image/jpeg, image/png
-                  - `request` : 스토리 등록 요청 정보 (필수, 허용 타입 : application/json)
+                  - image : 스토리 이미지 (필수, 최대 5MB, 허용 타입 : image/jpg, image/jpeg, image/png
+                  - request : 스토리 등록 요청 정보 (필수, 허용 타입 : application/json)
                 - request body 예시
                     ```json
                     {


### PR DESCRIPTION
## ✨ 개요
- Store API가 많아 Cheer API와 Store API로 분리
- 마크다운으로 작성한 내용 일부 표기 수정

## 🧾 관련 이슈

## 🔍 참고 사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * 테스트 문서의 태그를 일부 테스트 클래스에서 변경하여 REST API 문서의 메타데이터가 업데이트되었습니다.
  * 요청 필드 설명에서 마크다운 표기법을 수정하여 가독성을 개선하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->