### PR TITLE
[Hotfix] 임시적으로 응원 최대 개수를 인 당 10,000개까지 허용

### DIFF
--- a/src/main/java/eatda/service/cheer/CheerService.java
+++ b/src/main/java/eatda/service/cheer/CheerService.java
@@ -27,7 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CheerService {
 
-    private static final int MAX_CHEER_SIZE = 3;
+    private static final int MAX_CHEER_SIZE = 10_000;
 
     private final MemberRepository memberRepository;
     private final StoreRepository storeRepository;

--- a/src/test/java/eatda/service/cheer/CheerServiceTest.java
+++ b/src/test/java/eatda/service/cheer/CheerServiceTest.java
@@ -19,6 +19,7 @@ import eatda.exception.BusinessErrorCode;
 import eatda.exception.BusinessException;
 import eatda.service.BaseServiceTest;
 import java.time.LocalDateTime;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +33,7 @@ class CheerServiceTest extends BaseServiceTest {
     class RegisterCheer {
 
         @Test
+        @Disabled
         void 응원_개수가_최대_개수를_초과하면_예외가_발생한다() {
             Member member = memberGenerator.generate("123");
             Store store1 = storeGenerator.generate("124", "서울시 강남구 역삼동 123-45");


### PR DESCRIPTION
## ✨ 개요
- 초기 데이터 저장을 위해 임시적으로 인당 응원 10,000개까지 허용

## 🧾 관련 이슈

## 🔍 참고 사항 (선택)
- 초기 데이터 작업 종료 이후 롤백 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 사용자별 응원 등록 가능 수를 3개에서 10,000개로 확대했습니다. 더 많은 응원을 추가할 수 있으며, 기존 등록 흐름과 오류 처리, 응답 형식은 동일하게 유지됩니다. 변경 사항은 즉시 적용되며 기존 데이터에는 영향이 없습니다.
- Tests
  - 최대치 초과 검증 테스트가 임시로 비활성화되어 실행 대상에서 제외되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->