### PR TITLE
[Feat] '최신 응원 검색 API'의 유저 정보 추가

### DIFF
--- a/src/main/java/eatda/controller/cheer/CheerPreviewResponse.java
+++ b/src/main/java/eatda/controller/cheer/CheerPreviewResponse.java
@@ -1,7 +1,6 @@
 package eatda.controller.cheer;
 
 import eatda.domain.cheer.Cheer;
-import eatda.domain.store.Store;
 
 public record CheerPreviewResponse(
         long storeId,
@@ -11,19 +10,23 @@ public record CheerPreviewResponse(
         String storeNeighborhood,
         String storeCategory,
         long cheerId,
-        String cheerDescription
+        String cheerDescription,
+        long memberId,
+        String memberNickname
 ) {
 
-    public CheerPreviewResponse(Cheer cheer, Store store, String imageUrl) {
+    public CheerPreviewResponse(Cheer cheer, String imageUrl) {
         this(
-                store.getId(),
+                cheer.getStore().getId(),
                 imageUrl,
-                store.getName(),
-                store.getAddressDistrict(),
-                store.getAddressNeighborhood(),
-                store.getCategory().getCategoryName(),
+                cheer.getStore().getName(),
+                cheer.getStore().getAddressDistrict(),
+                cheer.getStore().getAddressNeighborhood(),
+                cheer.getStore().getCategory().getCategoryName(),
                 cheer.getId(),
-                cheer.getDescription()
+                cheer.getDescription(),
+                cheer.getMember().getId(),
+                cheer.getMember().getNickname()
         );
     }
 }

--- a/src/main/java/eatda/repository/cheer/CheerRepository.java
+++ b/src/main/java/eatda/repository/cheer/CheerRepository.java
@@ -7,13 +7,16 @@ import eatda.domain.store.Store;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface CheerRepository extends JpaRepository<Cheer, Long> {
 
+    @EntityGraph(attributePaths = {"store", "member"})
     List<Cheer> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
+    @EntityGraph(attributePaths = {"member"})
     List<Cheer> findAllByStoreOrderByCreatedAtDesc(Store store, Pageable pageable);
 
     @Query("""

--- a/src/main/java/eatda/service/cheer/CheerService.java
+++ b/src/main/java/eatda/service/cheer/CheerService.java
@@ -71,8 +71,7 @@ public class CheerService {
 
     private CheersResponse toCheersResponse(List<Cheer> cheers) {
         return new CheersResponse(cheers.stream()
-                .map(cheer -> new CheerPreviewResponse(cheer, cheer.getStore(),
-                        imageStorage.getPreSignedUrl(cheer.getImageKey())))
+                .map(cheer -> new CheerPreviewResponse(cheer, imageStorage.getPreSignedUrl(cheer.getImageKey())))
                 .toList());
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,10 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        jdbc:
+          batch_size: 100
+        order_inserts: true
+        order_updates: true
     defer-datasource-initialization: false
     open-in-view: false
 

--- a/src/test/java/eatda/document/store/CheerDocumentTest.java
+++ b/src/test/java/eatda/document/store/CheerDocumentTest.java
@@ -165,9 +165,9 @@ public class CheerDocumentTest extends BaseDocumentTest {
             int size = 2;
             CheersResponse responses = new CheersResponse(List.of(
                     new CheerPreviewResponse(2L, "https://example.image", "농민백암순대 본점", "강남구", "선릉구", "한식", 2L,
-                            "너무 맛있어요!"),
+                            "너무 맛있어요!", 5L, "커찬"),
                     new CheerPreviewResponse(1L, null, "석관동떡볶이", "성북구", "석관동", "기타", 1L,
-                            "너무 매워요! 하지만 맛있어요!")
+                            "너무 매워요! 하지만 맛있어요!", 8L, "찬커")
             ));
             doReturn(responses).when(cheerService).getCheers(page, size);
 

--- a/src/test/java/eatda/document/store/CheerDocumentTest.java
+++ b/src/test/java/eatda/document/store/CheerDocumentTest.java
@@ -156,7 +156,9 @@ public class CheerDocumentTest extends BaseDocumentTest {
                         fieldWithPath("cheers[].storeNeighborhood").type(STRING).description("가게 주소 (동)"),
                         fieldWithPath("cheers[].storeCategory").type(STRING).description("가게 카테고리"),
                         fieldWithPath("cheers[].cheerId").type(NUMBER).description("응원 ID"),
-                        fieldWithPath("cheers[].cheerDescription").type(STRING).description("응원 내용")
+                        fieldWithPath("cheers[].cheerDescription").type(STRING).description("응원 내용"),
+                        fieldWithPath("cheers[].memberId").type(NUMBER).description("응원 작성자 회원 ID"),
+                        fieldWithPath("cheers[].memberNickname").type(STRING).description("응원 작성자 닉네임")
                 );
 
         @Test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -29,6 +29,10 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        jdbc:
+          batch_size: 100
+        order_inserts: true
+        order_updates: true
     hibernate:
       ddl-auto: create-drop
     open-in-view: false


### PR DESCRIPTION
## ✨ 개요
- 기능 추가
    - '최신 응원 검색 API'에 회원 정보 추가
- 성능 개선
    - spring.jpa.properties 일부 설정을 통해 배치 형식으로 쿼리를 처리하도록 개선
    - `@EntityGraph`를 활용하여 쿼리 횟수를 N+1 개에서 1개로 횟수 감소

## 🧾 관련 이슈
closed #164 

## 🔍 참고 사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 응원 목록 응답에 작성자 정보(memberId, memberNickname) 필드가 추가되었습니다.
- 성능
  - 목록 조회 시 관련 엔티티를 함께 로딩하여 응답 속도를 개선했습니다.
  - 배치 쓰기 및 정렬 설정으로 데이터베이스 쓰기 효율을 향상했습니다.
- 문서
  - 응원 조회 API 문서에 신규 작성자 필드가 반영되었습니다.
- 테스트
  - 변경된 응답 스키마에 맞춰 통합 테스트와 예시 응답을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->