### PR TITLE
[Refactor] terraform deprecated 된 명령어인 name을 id로 변경

### DIFF
--- a/terraform/common/locals.tf
+++ b/terraform/common/locals.tf
@@ -42,9 +42,9 @@ locals {
                 Effect = "Allow"
                 Action = ["ssm:GetParameter", "ssm:GetParametersByPath"]
                 Resource = [
-                  "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/dev/MYSQL_URL",
-                  "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/dev/MYSQL_USER_NAME",
-                  "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/dev/MYSQL_PASSWORD"
+                  "arn:aws:ssm:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:parameter/dev/MYSQL_URL",
+                  "arn:aws:ssm:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:parameter/dev/MYSQL_USER_NAME",
+                  "arn:aws:ssm:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:parameter/dev/MYSQL_PASSWORD"
                 ]
               }
             ]
@@ -87,14 +87,14 @@ locals {
                 Effect = "Allow",
                 Action = ["ssm:GetParametersByPath", "ssm:GetParameter"],
                 Resource = [
-                  "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/dev/*",
-                  "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/prod/*"
+                  "arn:aws:ssm:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:parameter/dev/*",
+                  "arn:aws:ssm:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:parameter/prod/*"
                 ]
               },
               {
                 Effect   = "Allow",
                 Action   = "kms:Decrypt",
-                Resource = "arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:alias/aws/ssm"
+                Resource = "arn:aws:kms:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:alias/aws/ssm"
               }
             ]
           }


### PR DESCRIPTION
## ✨ 개요
- deprecated 된 명령어인 data.aws_region.current.name을 data.aws_region.current.id로 변경하였습니다.
- 서비스와 인프라의 변동은 없습니다.

## 🧾 관련 이슈
Closed #185 

## 🔍 참고 사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 리전 식별 방식 정정으로 구성 파라미터 및 KMS 복호화 권한 경로 오류를 해소하여 간헐적 접근 실패를 방지했습니다. 다중 리전 환경에서 일관된 동작을 보장합니다.
- 유지보수
  - 인프라 접근 정책의 리전 참조를 정리해 권한 범위를 명확화했습니다. 운영 안정성과 가시성을 향상합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->