### PR TITLE
[Refactor] 비용 최적화를 위한 기존 WAF 규칙 삭제

### DIFF
--- a/terraform/common/waf/main.tf
+++ b/terraform/common/waf/main.tf
@@ -183,25 +183,6 @@ resource "aws_wafv2_web_acl" "this" {
     }
   }
 
-  rule {
-    name     = "Rate-Limit-Rule"
-    priority = 20
-    action {
-      block {}
-    }
-    statement {
-      rate_based_statement {
-        limit              = var.request_threshold
-        aggregate_key_type = "IP"
-      }
-    }
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "rate-limit-rule"
-      sampled_requests_enabled   = true
-    }
-  }
-
   # AWS Managed Core Rule Set
   rule {
     name     = "AWS-Managed-Core-Rule-Set"
@@ -218,86 +199,6 @@ resource "aws_wafv2_web_acl" "this" {
     visibility_config {
       cloudwatch_metrics_enabled = true
       metric_name                = "aws-managed-common"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  # Scanners & Probes Protection
-  rule {
-    name     = "AWS-Managed-Known-Bad-Inputs-Rule-Set"
-    priority = 40
-    override_action {
-      none {}
-    }
-    statement {
-      managed_rule_group_statement {
-        vendor_name = "AWS"
-        name        = "AWSManagedRulesKnownBadInputsRuleSet"
-      }
-    }
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "aws-managed-bad-inputs"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  # Reputation Lists Protection
-  rule {
-    name     = "AWS-Managed-Amazon-IP-Reputation-List"
-    priority = 50
-    override_action {
-      none {}
-    }
-    statement {
-      managed_rule_group_statement {
-        vendor_name = "AWS"
-        name        = "AWSManagedRulesAmazonIpReputationList"
-      }
-    }
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "aws-managed-ip-rep"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  # Anonymous IP list
-  rule {
-    name     = "AWS-Managed-Anonymous-IP-List"
-    priority = 70
-    override_action {
-      none {}
-    }
-    statement {
-      managed_rule_group_statement {
-        vendor_name = "AWS"
-        name        = "AWSManagedRulesAnonymousIpList"
-      }
-    }
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "aws-managed-anonymous-ip"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  # SQL database
-  rule {
-    name     = "AWS-Managed-SQLi-Rule-Set"
-    priority = 80
-    override_action {
-      none {}
-    }
-    statement {
-      managed_rule_group_statement {
-        vendor_name = "AWS"
-        name        = "AWSManagedRulesSQLiRuleSet"
-      }
-    }
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "aws-managed-sql-db"
       sampled_requests_enabled   = true
     }
   }


### PR DESCRIPTION
## ✨ 개요
- AWS WAF의 비용이 예상보다 많이 나오고 있어, 필수 규칙을 제외한 우선순위가 낮은 규칙을 삭제처리했습니다.
- 적용 후 WAF 비용은 월 8달러로 유지될것으로 보입니다.
- 대부분의 악성 요청이 커스텀 규칙인 Allow-Verified-Server-Requests에서 방어될것으로 보입니다.
- 적용 후 WAF 로그를 지속적으로 모니터링 할 예정입니다.

## 🧾 관련 이슈
Close #211 
## 🔍 참고 사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 웹 애플리케이션 방화벽 규칙 제거: 속도 제한 규칙, 알려진 나쁜 입력 감지, IP 신판 목록, 익명 IP 목록, SQL 주입 탐지 규칙이 비활성화되었습니다.
  * 기존 보안 규칙 구성이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->