### PR TITLE
[Refactor] 응원 등록 이미지 트랜잭션 분리 및 보상 트랜잭션 적용

### DIFF
--- a/src/main/java/eatda/client/file/FileClient.java
+++ b/src/main/java/eatda/client/file/FileClient.java
@@ -20,6 +20,7 @@ import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignReques
 public class FileClient {
 
     private static final int THREAD_POOL_SIZE = 5; // TODO 비동기 병렬처리 개선
+    private static final String PATH_DELIMITER = "/";
     private final S3Client s3Client;
     private final String bucket;
     private final S3Presigner s3Presigner;
@@ -55,7 +56,7 @@ public class FileClient {
         List<CompletableFuture<String>> futures = tempImageKeys.stream()
                 .map(tempImageKey -> CompletableFuture.supplyAsync(() -> {
                     String fileName = extractFileName(tempImageKey);
-                    String newPermanentKey = domainName + "/" + domainId + "/" + fileName;
+                    String newPermanentKey = domainName + PATH_DELIMITER + domainId + PATH_DELIMITER + fileName;
                     try {
                         copyObject(tempImageKey, newPermanentKey);
                         deleteObject(tempImageKey);
@@ -72,7 +73,7 @@ public class FileClient {
     }
 
     private String extractFileName(String fullKey) {
-        int index = fullKey.lastIndexOf('/');
+        int index = fullKey.lastIndexOf(PATH_DELIMITER);
         return index == -1 ? fullKey : fullKey.substring(index + 1);
     }
 

--- a/src/main/java/eatda/client/file/FileClient.java
+++ b/src/main/java/eatda/client/file/FileClient.java
@@ -3,12 +3,12 @@ package eatda.client.file;
 import eatda.exception.BusinessErrorCode;
 import eatda.exception.BusinessException;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
@@ -16,15 +16,14 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
+@Slf4j
 @Component
 public class FileClient {
 
-    private static final int THREAD_POOL_SIZE = 5; // TODO 비동기 병렬처리 개선
     private static final String PATH_DELIMITER = "/";
     private final S3Client s3Client;
     private final String bucket;
     private final S3Presigner s3Presigner;
-    private final ExecutorService executorService;
 
     public FileClient(S3Client s3Client,
                       @Value("${spring.cloud.aws.s3.bucket}") String bucket,
@@ -32,7 +31,6 @@ public class FileClient {
         this.s3Client = s3Client;
         this.bucket = bucket;
         this.s3Presigner = s3Presigner;
-        this.executorService = Executors.newFixedThreadPool(THREAD_POOL_SIZE);
     }
 
     public String generateUploadPresignedUrl(String fileKey, Duration signatureDuration) {
@@ -53,23 +51,31 @@ public class FileClient {
     }
 
     public List<String> moveTempFilesToPermanent(String domainName, long domainId, List<String> tempImageKeys) {
-        List<CompletableFuture<String>> futures = tempImageKeys.stream()
-                .map(tempImageKey -> CompletableFuture.supplyAsync(() -> {
-                    String fileName = extractFileName(tempImageKey);
-                    String newPermanentKey = domainName + PATH_DELIMITER + domainId + PATH_DELIMITER + fileName;
-                    try {
-                        copyObject(tempImageKey, newPermanentKey);
-                        deleteObject(tempImageKey);
-                        return newPermanentKey;
-                    } catch (Exception e) { //TODO 근본 예외 추가 필요
-                        throw new BusinessException(BusinessErrorCode.FAIL_TEMP_IMAGE_PROCESS);
-                    }
-                }, executorService))
-                .toList();
+        List<String> successKeys = new ArrayList<>();
 
-        return futures.stream()
-                .map(CompletableFuture::join) // TODO 일부 파일 에러에도 처리하도록 개선
-                .toList();
+        try {
+            for (String tempKey : tempImageKeys) {
+                String fileName = extractFileName(tempKey);
+                String newPermanentKey = domainName + PATH_DELIMITER + domainId + PATH_DELIMITER + fileName;
+
+                copyObject(tempKey, newPermanentKey);
+                deleteObject(tempKey);
+
+                successKeys.add(newPermanentKey);
+            }
+            return successKeys;
+        } catch (SdkException sdkException) {
+            log.error("S3 파일 이동 중 실패. 롤백 수행. successKeys={}", successKeys, sdkException);
+            deleteFiles(successKeys);
+            throw new BusinessException(BusinessErrorCode.FAIL_TEMP_IMAGE_PROCESS);
+        }
+    }
+
+    public void deleteFiles(List<String> keys) {
+        if (keys.isEmpty()) {
+            return;
+        }
+        keys.forEach(this::deleteObject);
     }
 
     private String extractFileName(String fullKey) {

--- a/src/main/java/eatda/controller/cheer/CheerController.java
+++ b/src/main/java/eatda/controller/cheer/CheerController.java
@@ -6,6 +6,7 @@ import eatda.domain.ImageDomain;
 import eatda.domain.cheer.CheerTagName;
 import eatda.domain.store.StoreCategory;
 import eatda.domain.store.StoreSearchResult;
+import eatda.facade.CheerRegisterFacade;
 import eatda.service.cheer.CheerService;
 import eatda.service.store.StoreSearchService;
 import jakarta.validation.constraints.Max;
@@ -29,13 +30,14 @@ public class CheerController {
 
     private final CheerService cheerService;
     private final StoreSearchService storeSearchService;
+    private final CheerRegisterFacade cheerRegisterFacade;
 
     @PostMapping("/api/cheer")
     public ResponseEntity<CheerResponse> registerCheer(@RequestBody CheerRegisterRequest request,
                                                        LoginMember member) {
         StoreSearchResult searchResult = storeSearchService.searchStoreByKakaoId(
                 request.storeName(), request.storeKakaoId());
-        CheerResponse response = cheerService.registerCheer(request, searchResult, member.id(), ImageDomain.CHEER);
+        CheerResponse response = cheerRegisterFacade.registerCheer(request, searchResult, member.id(), ImageDomain.CHEER);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(response);
     }

--- a/src/main/java/eatda/controller/cheer/CheerResponse.java
+++ b/src/main/java/eatda/controller/cheer/CheerResponse.java
@@ -2,7 +2,6 @@ package eatda.controller.cheer;
 
 import eatda.domain.cheer.Cheer;
 import eatda.domain.cheer.CheerTagName;
-import eatda.domain.store.Store;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -15,12 +14,12 @@ public record CheerResponse(
         List<CheerTagName> tags
 ) {
 
-    public CheerResponse(Cheer cheer, Store store, String cdnBaseUrl) {
+    public CheerResponse(Cheer cheer, String cdnBaseUrl) {
         this(
-                store.getId(),
+                cheer.getStore().getId(),
                 cheer.getId(),
                 cheer.getImages().stream()
-                        .map(img -> new CheerImageResponse(img, cdnBaseUrl)) // ✅ CDN 붙여줌
+                        .map(img -> new CheerImageResponse(img, cdnBaseUrl))
                         .sorted(Comparator.comparingLong(CheerImageResponse::orderIndex))
                         .collect(Collectors.toList()),
                 cheer.getDescription(),

--- a/src/main/java/eatda/exception/BusinessErrorCode.java
+++ b/src/main/java/eatda/exception/BusinessErrorCode.java
@@ -28,6 +28,7 @@ public enum BusinessErrorCode {
     INVALID_CHEER_IMAGE_KEY("CHE002", "응원 이미지 키가 비어 있습니다.", HttpStatus.BAD_REQUEST),
     FULL_CHEER_SIZE_PER_MEMBER("CHE003", "회원당 응원 한도가 넘었습니다."),
     ALREADY_CHEERED("CHE004", "이미 응원한 가게입니다."),
+    CHEER_NOT_FOUND("CHE005", "응원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
     // CheerTag
     CHEER_TAGS_DUPLICATED("CHE_TAG001", "응원 태그는 중복될 수 없습니다."),

--- a/src/main/java/eatda/facade/CheerCreationResult.java
+++ b/src/main/java/eatda/facade/CheerCreationResult.java
@@ -1,0 +1,7 @@
+package eatda.facade;
+
+import eatda.domain.cheer.Cheer;
+import eatda.domain.store.Store;
+
+public record CheerCreationResult(Cheer cheer, Store store) {
+}

--- a/src/main/java/eatda/facade/CheerRegisterFacade.java
+++ b/src/main/java/eatda/facade/CheerRegisterFacade.java
@@ -12,6 +12,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.exception.SdkException;
 
 @Component
 @RequiredArgsConstructor
@@ -34,9 +35,9 @@ public class CheerRegisterFacade {
             List<CheerRegisterRequest.UploadedImageDetail> sortedImages = sortImages(request.images());
             List<String> permanentKeys = moveImages(domain, cheer.getId(), sortedImages);
             cheer = cheerService.saveCheerImages(cheer.getId(), sortedImages, permanentKeys);
-        } catch (Exception e) {
+        } catch (SdkException sdkException) {
             cheerService.deleteCheer(cheer.getId());
-            throw e;
+            throw sdkException;
         }
 
         return new CheerResponse(cheer, creationResult.store(), cdnBaseUrl);

--- a/src/main/java/eatda/facade/CheerRegisterFacade.java
+++ b/src/main/java/eatda/facade/CheerRegisterFacade.java
@@ -1,0 +1,60 @@
+package eatda.facade;
+
+import eatda.client.file.FileClient;
+import eatda.controller.cheer.CheerRegisterRequest;
+import eatda.controller.cheer.CheerResponse;
+import eatda.domain.ImageDomain;
+import eatda.domain.cheer.Cheer;
+import eatda.domain.store.StoreSearchResult;
+import eatda.service.cheer.CheerService;
+import java.util.Comparator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CheerRegisterFacade {
+
+    @Value("${cdn.base-url}")
+    private String cdnBaseUrl;
+    private final CheerService cheerService;
+    private final FileClient fileClient;
+
+    public CheerResponse registerCheer(CheerRegisterRequest request,
+                                       StoreSearchResult result,
+                                       long memberId,
+                                       ImageDomain domain
+    ) {
+        CheerCreationResult creationResult = cheerService.createCheer(request, result, memberId);
+        Cheer cheer = creationResult.cheer();
+
+        try {
+            List<CheerRegisterRequest.UploadedImageDetail> sortedImages = sortImages(request.images());
+            List<String> permanentKeys = moveImages(domain, cheer.getId(), sortedImages);
+            cheer = cheerService.saveCheerImages(cheer.getId(), sortedImages, permanentKeys);
+        } catch (Exception e) {
+            cheerService.deleteCheer(cheer.getId());
+            throw e;
+        }
+
+        return new CheerResponse(cheer, creationResult.store(), cdnBaseUrl);
+    }
+
+    private List<CheerRegisterRequest.UploadedImageDetail> sortImages(
+            List<CheerRegisterRequest.UploadedImageDetail> images) {
+        return images.stream()
+                .sorted(Comparator.comparingLong(CheerRegisterRequest.UploadedImageDetail::orderIndex))
+                .toList();
+    }
+
+    private List<String> moveImages(ImageDomain domain,
+                                    long cheerId,
+                                    List<CheerRegisterRequest.UploadedImageDetail> sortedImages) {
+        List<String> tempKeys = sortedImages.stream()
+                .map(CheerRegisterRequest.UploadedImageDetail::imageKey)
+                .toList();
+        return fileClient.moveTempFilesToPermanent(domain.getName(), cheerId, tempKeys);
+    }
+}

--- a/src/test/java/eatda/document/BaseDocumentTest.java
+++ b/src/test/java/eatda/document/BaseDocumentTest.java
@@ -7,6 +7,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import eatda.controller.web.jwt.JwtManager;
 import eatda.exception.BusinessErrorCode;
 import eatda.exception.EtcErrorCode;
+import eatda.facade.CheerRegisterFacade;
 import eatda.service.auth.AuthService;
 import eatda.service.auth.OauthService;
 import eatda.service.cheer.CheerService;
@@ -65,6 +66,9 @@ public abstract class BaseDocumentTest {
 
     @MockitoBean
     protected PresignedUrlService presignedUrlService;
+
+    @MockitoBean
+    protected CheerRegisterFacade cheerRegisterFacade;
 
     @MockitoBean
     protected JwtManager jwtManager;

--- a/src/test/java/eatda/document/cheer/CheerDocumentTest.java
+++ b/src/test/java/eatda/document/cheer/CheerDocumentTest.java
@@ -99,7 +99,7 @@ public class CheerDocumentTest extends BaseDocumentTest {
                     List.of(CheerTagName.GOOD_FOR_DATING, CheerTagName.CLEAN_RESTROOM)
             );
 
-            doReturn(response).when(cheerService).registerCheer(eq(request), any(), anyLong(), any());
+            doReturn(response).when(cheerService).createCheer(eq(request), any(), anyLong());
 
             var document = document("cheer/register", 201)
                     .request(requestDocument)
@@ -137,7 +137,7 @@ public class CheerDocumentTest extends BaseDocumentTest {
             );
 
             doThrow(new BusinessException(errorCode))
-                    .when(cheerService).registerCheer(eq(request), any(), anyLong(), any());
+                    .when(cheerService).createCheer(eq(request), any(), anyLong());
 
             var document = document("cheer/register", errorCode)
                     .request(requestDocument)

--- a/src/test/java/eatda/document/cheer/CheerDocumentTest.java
+++ b/src/test/java/eatda/document/cheer/CheerDocumentTest.java
@@ -99,7 +99,7 @@ public class CheerDocumentTest extends BaseDocumentTest {
                     List.of(CheerTagName.GOOD_FOR_DATING, CheerTagName.CLEAN_RESTROOM)
             );
 
-            doReturn(response).when(cheerService).createCheer(eq(request), any(), anyLong());
+            doReturn(response).when(cheerRegisterFacade).registerCheer(eq(request), any(), anyLong(), any());
 
             var document = document("cheer/register", 201)
                     .request(requestDocument)
@@ -137,7 +137,7 @@ public class CheerDocumentTest extends BaseDocumentTest {
             );
 
             doThrow(new BusinessException(errorCode))
-                    .when(cheerService).createCheer(eq(request), any(), anyLong());
+                    .when(cheerRegisterFacade).registerCheer(eq(request), any(), anyLong(), any());
 
             var document = document("cheer/register", errorCode)
                     .request(requestDocument)

--- a/src/test/java/eatda/facade/BaseFacadeTest.java
+++ b/src/test/java/eatda/facade/BaseFacadeTest.java
@@ -1,0 +1,36 @@
+package eatda.facade;
+
+import eatda.DatabaseCleaner;
+import eatda.client.file.FileClient;
+import eatda.client.map.MapClient;
+import eatda.client.oauth.OauthClient;
+import eatda.fixture.MemberGenerator;
+import eatda.fixture.StoreGenerator;
+import eatda.repository.cheer.CheerRepository;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@ExtendWith(DatabaseCleaner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+public abstract class BaseFacadeTest {
+
+    @MockitoBean
+    protected OauthClient oauthClient;
+
+    @MockitoBean
+    protected MapClient mapClient;
+
+    @MockitoBean
+    protected FileClient fileClient;
+
+    @Autowired
+    protected MemberGenerator memberGenerator;
+
+    @Autowired
+    protected StoreGenerator storeGenerator;
+
+    @Autowired
+    protected CheerRepository cheerRepository;
+}

--- a/src/test/java/eatda/facade/cheer/CheerRegisterFacadeTest.java
+++ b/src/test/java/eatda/facade/cheer/CheerRegisterFacadeTest.java
@@ -207,12 +207,13 @@ class CheerRegisterFacadeTest extends BaseFacadeTest {
                         ImageDomain.CHEER
                 );
             } catch (Exception ignored) {
-                assertThat(cheerRepository.count())
-                        .as("DB 에러(컬럼 길이 초과) 발생 시 응원글은 삭제되어야 한다.")
-                        .isZero();
-
-                verify(fileClient).deleteFiles(movedKeys);
             }
+
+            assertThat(cheerRepository.count())
+                    .as("DB 에러(컬럼 길이 초과) 발생 시 응원글은 삭제되어야 한다.")
+                    .isZero();
+
+            verify(fileClient).deleteFiles(movedKeys);
         }
 
         @Test

--- a/src/test/java/eatda/facade/cheer/CheerRegisterFacadeTest.java
+++ b/src/test/java/eatda/facade/cheer/CheerRegisterFacadeTest.java
@@ -1,0 +1,243 @@
+package eatda.facade.cheer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import eatda.controller.cheer.CheerRegisterRequest;
+import eatda.controller.cheer.CheerResponse;
+import eatda.domain.ImageDomain;
+import eatda.domain.cheer.CheerTagName;
+import eatda.domain.store.District;
+import eatda.domain.store.StoreCategory;
+import eatda.domain.store.StoreSearchResult;
+import eatda.facade.BaseFacadeTest;
+import eatda.facade.CheerRegisterFacade;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import software.amazon.awssdk.core.exception.SdkException;
+
+class CheerRegisterFacadeTest extends BaseFacadeTest {
+
+    @Autowired
+    private CheerRegisterFacade cheerRegisterFacade;
+
+    @Nested
+    class RegisterCheer {
+
+        @Test
+        void 응원을_등록하면_이미지를_이동하고_최종_응답을_반환한다() {
+            var member = memberGenerator.generate("member-1");
+
+            CheerRegisterRequest.UploadedImageDetail image1 =
+                    new CheerRegisterRequest.UploadedImageDetail("temp/key1.jpg", 1L, "image/jpeg", 1000L);
+            CheerRegisterRequest.UploadedImageDetail image2 =
+                    new CheerRegisterRequest.UploadedImageDetail("temp/key2.jpg", 2L, "image/jpeg", 2000L);
+
+            CheerRegisterRequest request = new CheerRegisterRequest(
+                    "kakao-1",
+                    "농민백암순대",
+                    "맛있어요",
+                    List.of(image1, image2),
+                    List.of(CheerTagName.GOOD_FOR_DATING)
+            );
+
+            StoreSearchResult storeResult = new StoreSearchResult(
+                    "kakao-1",
+                    StoreCategory.KOREAN,
+                    "02-000-0000",
+                    "농민백암순대",
+                    "http://place.map.kakao.com/1",
+                    "서울시 강남구",
+                    "서울시 강남구",
+                    District.GANGNAM,
+                    37.715132,
+                    127.269310
+            );
+
+            given(fileClient.moveTempFilesToPermanent(
+                    eq(ImageDomain.CHEER.getName()),
+                    anyLong(),
+                    anyList()
+            )).willReturn(List.of(
+                    "cheer/1/key1.jpg",
+                    "cheer/1/key2.jpg"
+            ));
+
+            CheerResponse response = cheerRegisterFacade.registerCheer(
+                    request,
+                    storeResult,
+                    member.getId(),
+                    ImageDomain.CHEER
+            );
+
+            assertThat(response.cheerDescription()).isEqualTo("맛있어요");
+            assertThat(response.tags()).containsExactly(CheerTagName.GOOD_FOR_DATING);
+            assertThat(response.images()).hasSize(2);
+
+            Mockito.verify(fileClient)
+                    .moveTempFilesToPermanent(
+                            eq(ImageDomain.CHEER.getName()),
+                            anyLong(),
+                            anyList()
+                    );
+        }
+
+        @Test
+        void 이미지_이동_중_실패하면_응원을_삭제한다() {
+            var member = memberGenerator.generate("member-1");
+
+            CheerRegisterRequest.UploadedImageDetail image =
+                    new CheerRegisterRequest.UploadedImageDetail(
+                            "temp/key1.jpg", 1L, "image/jpeg", 1000L
+                    );
+
+            CheerRegisterRequest request = new CheerRegisterRequest(
+                    "kakao-1",
+                    "농민백암순대",
+                    "맛있어요",
+                    List.of(image),
+                    List.of(CheerTagName.GOOD_FOR_DATING)
+            );
+
+            StoreSearchResult storeResult = new StoreSearchResult(
+                    "kakao-1",
+                    StoreCategory.KOREAN,
+                    "02-000-0000",
+                    "농민백암순대",
+                    "http://place.map.kakao.com/1",
+                    "서울시 강남구",
+                    "서울시 강남구",
+                    District.GANGNAM,
+                    37.715132,
+                    127.269310
+            );
+
+            given(fileClient.moveTempFilesToPermanent(
+                    anyString(),
+                    anyLong(),
+                    anyList()
+            )).willThrow(
+                    software.amazon.awssdk.core.exception.SdkException.builder().build()
+            );
+
+            try {
+                cheerRegisterFacade.registerCheer(
+                        request,
+                        storeResult,
+                        member.getId(),
+                        ImageDomain.CHEER
+                );
+            } catch (Exception ignored) {
+            }
+
+            assertThat(cheerRepository.count()).isZero();
+        }
+
+        @Test
+        void 이미지가_없어도_응원은_정상_등록된다() {
+            var member = memberGenerator.generate("member-1");
+
+            CheerRegisterRequest request = new CheerRegisterRequest(
+                    "kakao-1",
+                    "농민백암순대",
+                    "이미지 없음",
+                    List.of(),
+                    List.of(CheerTagName.GOOD_FOR_DATING)
+            );
+
+            StoreSearchResult storeResult = new StoreSearchResult(
+                    "kakao-1",
+                    StoreCategory.KOREAN,
+                    "02-000-0000",
+                    "농민백암순대",
+                    "http://place.map.kakao.com/1",
+                    "서울시 강남구",
+                    "서울시 강남구",
+                    District.GANGNAM,
+                    37.715132,
+                    127.269310
+            );
+
+            CheerResponse response = cheerRegisterFacade.registerCheer(
+                    request,
+                    storeResult,
+                    member.getId(),
+                    ImageDomain.CHEER
+            );
+
+            assertThat(response.images()).isEmpty();
+            assertThat(cheerRepository.count()).isEqualTo(1);
+
+            Mockito.verify(fileClient, Mockito.never())
+                    .moveTempFilesToPermanent(anyString(), anyLong(), anyList());
+        }
+
+        @Test
+        void 이미지_이동이_부분적으로_성공한_후_실패하면_응원을_삭제한다() {
+            var member = memberGenerator.generate("member-1");
+
+            CheerRegisterRequest.UploadedImageDetail image1 =
+                    new CheerRegisterRequest.UploadedImageDetail(
+                            "temp/key1.jpg", 1L, "image/jpeg", 1000L
+                    );
+            CheerRegisterRequest.UploadedImageDetail image2 =
+                    new CheerRegisterRequest.UploadedImageDetail(
+                            "temp/key2.jpg", 2L, "image/jpeg", 1000L
+                    );
+            CheerRegisterRequest.UploadedImageDetail image3 =
+                    new CheerRegisterRequest.UploadedImageDetail(
+                            "temp/key3.jpg", 3L, "image/jpeg", 1000L
+                    );
+
+            CheerRegisterRequest request = new CheerRegisterRequest(
+                    "kakao-1",
+                    "농민백암순대",
+                    "부분 성공 테스트",
+                    List.of(image1, image2, image3),
+                    List.of(CheerTagName.GOOD_FOR_DATING)
+            );
+
+            StoreSearchResult storeResult = new StoreSearchResult(
+                    "kakao-1",
+                    StoreCategory.KOREAN,
+                    "02-000-0000",
+                    "농민백암순대",
+                    "http://place.map.kakao.com/1",
+                    "서울시 강남구",
+                    "서울시 강남구",
+                    District.GANGNAM,
+                    37.715132,
+                    127.269310
+            );
+
+            given(fileClient.moveTempFilesToPermanent(
+                    eq(ImageDomain.CHEER.getName()),
+                    anyLong(),
+                    anyList()
+            )).willAnswer(invocation -> {
+                throw SdkException.builder().build();
+            });
+
+            try {
+                cheerRegisterFacade.registerCheer(
+                        request,
+                        storeResult,
+                        member.getId(),
+                        ImageDomain.CHEER
+                );
+            } catch (Exception ignored) {
+            }
+
+            assertThat(cheerRepository.count())
+                    .as("부분 성공 후 실패 시 Cheer는 삭제되어야 한다")
+                    .isZero();
+        }
+    }
+}

--- a/src/test/java/eatda/facade/cheer/CheerRegisterFacadeTest.java
+++ b/src/test/java/eatda/facade/cheer/CheerRegisterFacadeTest.java
@@ -1,6 +1,7 @@
 package eatda.facade.cheer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -118,15 +119,14 @@ class CheerRegisterFacadeTest extends BaseFacadeTest {
                     SdkException.builder().build()
             );
 
-            try {
-                cheerRegisterFacade.registerCheer(
-                        request,
-                        storeResult,
-                        member.getId(),
-                        ImageDomain.CHEER
-                );
-            } catch (Exception ignored) {
-            }
+            assertThrows(SdkException.class, () ->
+                    cheerRegisterFacade.registerCheer(
+                            request,
+                            storeResult,
+                            member.getId(),
+                            ImageDomain.CHEER
+                    )
+            );
 
             assertThat(cheerRepository.count()).isZero();
         }
@@ -158,15 +158,14 @@ class CheerRegisterFacadeTest extends BaseFacadeTest {
                 throw SdkException.builder().build();
             });
 
-            try {
-                cheerRegisterFacade.registerCheer(
-                        request,
-                        storeResult,
-                        member.getId(),
-                        ImageDomain.CHEER
-                );
-            } catch (Exception ignored) {
-            }
+            assertThrows(SdkException.class, () ->
+                    cheerRegisterFacade.registerCheer(
+                            request,
+                            storeResult,
+                            member.getId(),
+                            ImageDomain.CHEER
+                    )
+            );
 
             assertThat(cheerRepository.count())
                     .as("부분 성공 후 실패 시 Cheer는 삭제되어야 한다.")
@@ -199,21 +198,21 @@ class CheerRegisterFacadeTest extends BaseFacadeTest {
             given(fileClient.moveTempFilesToPermanent(anyString(), anyLong(), anyList()))
                     .willReturn(movedKeys);
 
-            try {
-                cheerRegisterFacade.registerCheer(
-                        request,
-                        storeResult,
-                        member.getId(),
-                        ImageDomain.CHEER
-                );
-            } catch (Exception ignored) {
-            }
+            assertThrows(Exception.class, () ->
+                    cheerRegisterFacade.registerCheer(
+                            request,
+                            storeResult,
+                            member.getId(),
+                            ImageDomain.CHEER
+                    )
+            );
 
             assertThat(cheerRepository.count())
                     .as("DB 에러(컬럼 길이 초과) 발생 시 응원글은 삭제되어야 한다.")
                     .isZero();
 
             verify(fileClient).deleteFiles(movedKeys);
+
         }
 
         @Test

--- a/src/test/java/eatda/service/cheer/CheerServiceTest.java
+++ b/src/test/java/eatda/service/cheer/CheerServiceTest.java
@@ -57,7 +57,7 @@ class CheerServiceTest extends BaseServiceTest {
                     "123", StoreCategory.KOREAN, "02-755-5232", "농민백암순대 본점", "http://place.map.kakao.com/123",
                     "서울시 강남구 역삼동 123-45", "서울시 강남구 역삼동 123-45", District.GANGNAM, 37.5665, 126.9780);
 
-            assertThatThrownBy(() -> cheerService.registerCheer(request, result, member.getId(), ImageDomain.CHEER))
+            assertThatThrownBy(() -> cheerService.createCheer(request, result, member.getId(), ImageDomain.CHEER))
                     .isInstanceOf(BusinessException.class)
                     .hasMessageContaining(BusinessErrorCode.FULL_CHEER_SIZE_PER_MEMBER.getMessage());
         }
@@ -76,7 +76,7 @@ class CheerServiceTest extends BaseServiceTest {
                     "123", StoreCategory.KOREAN, "02-755-5232", "농민백암순대 본점", "http://place.map.kakao.com/123",
                     "서울시 강남구 역삼동 123-45", "서울시 강남구 역삼동 123-45", District.GANGNAM, 37.5665, 126.9780);
 
-            assertThatThrownBy(() -> cheerService.registerCheer(request, result, member.getId(), ImageDomain.CHEER))
+            assertThatThrownBy(() -> cheerService.createCheer(request, result, member.getId(), ImageDomain.CHEER))
                     .isInstanceOf(BusinessException.class)
                     .hasMessageContaining(BusinessErrorCode.ALREADY_CHEERED.getMessage());
         }
@@ -93,7 +93,7 @@ class CheerServiceTest extends BaseServiceTest {
                     "123", StoreCategory.KOREAN, "02-755-5232", "농민백암순대 본점", "http://place.map.kakao.com/123",
                     "서울시 강남구 역삼동 123-45", "서울시 강남구 역삼동 123-45", District.GANGNAM, 37.5665, 126.9780);
 
-            CheerResponse response = cheerService.registerCheer(request, result, member.getId(), ImageDomain.CHEER);
+            CheerResponse response = cheerService.createCheer(request, result, member.getId(), ImageDomain.CHEER);
 
             Store foundStore = storeRepository.findByKakaoId("123").orElseThrow();
             assertAll(
@@ -117,7 +117,7 @@ class CheerServiceTest extends BaseServiceTest {
                     "123", StoreCategory.KOREAN, "02-755-5232", "농민백암순대 본점", "http://place.map.kakao.com/123",
                     "서울시 강남구 역삼동 123-45", "서울시 강남구 역삼동 123-45", District.GANGNAM, 37.5665, 126.9780);
 
-            CheerResponse response = cheerService.registerCheer(request, result, member.getId(), ImageDomain.CHEER);
+            CheerResponse response = cheerService.createCheer(request, result, member.getId(), ImageDomain.CHEER);
 
             assertAll(
                     () -> assertThat(response.storeId()).isEqualTo(store.getId()),
@@ -140,7 +140,7 @@ class CheerServiceTest extends BaseServiceTest {
                     "123", StoreCategory.KOREAN, "02-755-5232", "농민백암순대 본점", "http://place.map.kakao.com/123",
                     "서울시 강남구 역삼동 123-45", "서울시 강남구 역삼동 123-45", District.GANGNAM, 37.5665, 126.9780);
 
-            CheerResponse response = cheerService.registerCheer(request, result, member.getId(), ImageDomain.CHEER);
+            CheerResponse response = cheerService.createCheer(request, result, member.getId(), ImageDomain.CHEER);
 
             assertAll(
                     () -> assertThat(response.cheerDescription()).isEqualTo("맛있어요!"),
@@ -158,7 +158,7 @@ class CheerServiceTest extends BaseServiceTest {
                     "123", StoreCategory.KOREAN, "02-755-5232", "농민백암순대 본점", "http://place.map.kakao.com/123",
                     "서울시 강남구 역삼동 123-45", "서울시 강남구 역삼동 123-45", District.GANGNAM, 37.5665, 126.9780);
 
-            CheerResponse response = cheerService.registerCheer(request, result, member.getId(), ImageDomain.CHEER);
+            CheerResponse response = cheerService.createCheer(request, result, member.getId(), ImageDomain.CHEER);
 
             Store foundStore = storeRepository.findByKakaoId("123").orElseThrow();
             assertAll(

--- a/src/test/java/eatda/service/cheer/CheerServiceTest.java
+++ b/src/test/java/eatda/service/cheer/CheerServiceTest.java
@@ -4,14 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import eatda.controller.cheer.CheerImageResponse;
 import eatda.controller.cheer.CheerRegisterRequest;
-import eatda.controller.cheer.CheerResponse;
 import eatda.controller.cheer.CheerSearchParameters;
-import eatda.controller.cheer.CheersInStoreResponse;
-import eatda.controller.cheer.CheersResponse;
 import eatda.controller.store.SearchDistrict;
-import eatda.domain.ImageDomain;
 import eatda.domain.cheer.Cheer;
 import eatda.domain.cheer.CheerTagName;
 import eatda.domain.member.Member;
@@ -21,9 +16,9 @@ import eatda.domain.store.StoreCategory;
 import eatda.domain.store.StoreSearchResult;
 import eatda.exception.BusinessErrorCode;
 import eatda.exception.BusinessException;
+import eatda.facade.CheerCreationResult;
 import eatda.service.BaseServiceTest;
 import java.time.LocalDateTime;
-import java.util.Comparator;
 import java.util.List;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
@@ -49,15 +44,19 @@ class CheerServiceTest extends BaseServiceTest {
             cheerGenerator.generateCommon(member, store2);
             cheerGenerator.generateCommon(member, store3);
 
-            CheerRegisterRequest request = new CheerRegisterRequest("123", "농민백암순대 본점", "추가 응원",
+            CheerRegisterRequest request = new CheerRegisterRequest(
+                    "123",
+                    "농민백암순대 본점",
+                    "추가 응원",
                     List.of(),
-                    List.of(CheerTagName.GOOD_FOR_DATING, CheerTagName.CLEAN_RESTROOM));
+                    List.of(CheerTagName.GOOD_FOR_DATING, CheerTagName.CLEAN_RESTROOM)
+            );
 
-            StoreSearchResult result = new StoreSearchResult(
-                    "123", StoreCategory.KOREAN, "02-755-5232", "농민백암순대 본점", "http://place.map.kakao.com/123",
-                    "서울시 강남구 역삼동 123-45", "서울시 강남구 역삼동 123-45", District.GANGNAM, 37.5665, 126.9780);
+            StoreSearchResult result = storeSearchResult("123");
 
-            assertThatThrownBy(() -> cheerService.createCheer(request, result, member.getId(), ImageDomain.CHEER))
+            assertThatThrownBy(() ->
+                    cheerService.createCheer(request, result, member.getId())
+            )
                     .isInstanceOf(BusinessException.class)
                     .hasMessageContaining(BusinessErrorCode.FULL_CHEER_SIZE_PER_MEMBER.getMessage());
         }
@@ -68,15 +67,19 @@ class CheerServiceTest extends BaseServiceTest {
             Store store = storeGenerator.generate("123", "서울시 강남구 역삼동 123-45");
             cheerGenerator.generateCommon(member, store);
 
-            CheerRegisterRequest request = new CheerRegisterRequest("123", "농민백암순대 본점", "추가 응원",
+            CheerRegisterRequest request = new CheerRegisterRequest(
+                    "123",
+                    "농민백암순대 본점",
+                    "추가 응원",
                     List.of(),
-                    List.of(CheerTagName.GOOD_FOR_DATING, CheerTagName.CLEAN_RESTROOM));
+                    List.of(CheerTagName.GOOD_FOR_DATING, CheerTagName.CLEAN_RESTROOM)
+            );
 
-            StoreSearchResult result = new StoreSearchResult(
-                    "123", StoreCategory.KOREAN, "02-755-5232", "농민백암순대 본점", "http://place.map.kakao.com/123",
-                    "서울시 강남구 역삼동 123-45", "서울시 강남구 역삼동 123-45", District.GANGNAM, 37.5665, 126.9780);
+            StoreSearchResult result = storeSearchResult("123");
 
-            assertThatThrownBy(() -> cheerService.createCheer(request, result, member.getId(), ImageDomain.CHEER))
+            assertThatThrownBy(() ->
+                    cheerService.createCheer(request, result, member.getId())
+            )
                     .isInstanceOf(BusinessException.class)
                     .hasMessageContaining(BusinessErrorCode.ALREADY_CHEERED.getMessage());
         }
@@ -85,23 +88,33 @@ class CheerServiceTest extends BaseServiceTest {
         void 해당_응원의_가게가_저장되어_있지_않다면_가게와_응원을_저장한다() {
             Member member = memberGenerator.generate("123");
 
-            CheerRegisterRequest request = new CheerRegisterRequest("123", "농민백암순대 본점", "맛있어요!",
+            CheerRegisterRequest request = new CheerRegisterRequest(
+                    "123",
+                    "농민백암순대 본점",
+                    "맛있어요!",
                     List.of(),
-                    List.of(CheerTagName.GOOD_FOR_DATING, CheerTagName.CLEAN_RESTROOM));
+                    List.of(CheerTagName.GOOD_FOR_DATING, CheerTagName.CLEAN_RESTROOM)
+            );
 
-            StoreSearchResult result = new StoreSearchResult(
-                    "123", StoreCategory.KOREAN, "02-755-5232", "농민백암순대 본점", "http://place.map.kakao.com/123",
-                    "서울시 강남구 역삼동 123-45", "서울시 강남구 역삼동 123-45", District.GANGNAM, 37.5665, 126.9780);
+            StoreSearchResult result = storeSearchResult("123");
 
-            CheerResponse response = cheerService.createCheer(request, result, member.getId(), ImageDomain.CHEER);
+            CheerCreationResult creationResult =
+                    cheerService.createCheer(request, result, member.getId());
 
+            Cheer cheer = creationResult.cheer();
+            Store store = creationResult.store();
             Store foundStore = storeRepository.findByKakaoId("123").orElseThrow();
+
             assertAll(
-                    () -> assertThat(response.storeId()).isEqualTo(foundStore.getId()),
-                    () -> assertThat(response.cheerDescription()).isEqualTo("맛있어요!"),
+                    () -> assertThat(store.getId()).isEqualTo(foundStore.getId()),
+                    () -> assertThat(cheer.getDescription()).isEqualTo("맛있어요!"),
                     () -> assertThat(cheerRepository.count()).isEqualTo(1),
-                    () -> assertThat(response.tags()).containsExactlyInAnyOrder(
-                            CheerTagName.GOOD_FOR_DATING, CheerTagName.CLEAN_RESTROOM)
+                    () -> assertThat(
+                            cheer.getCheerTags().getNames()
+                    ).containsExactlyInAnyOrder(
+                            CheerTagName.GOOD_FOR_DATING,
+                            CheerTagName.CLEAN_RESTROOM
+                    )
             );
         }
 
@@ -110,21 +123,24 @@ class CheerServiceTest extends BaseServiceTest {
             Member member = memberGenerator.generate("123");
             Store store = storeGenerator.generate("123", "서울시 강남구 역삼동 123-45");
 
-            CheerRegisterRequest request = new CheerRegisterRequest("123", "농민백암순대 본점", "맛있어요!",
+            CheerRegisterRequest request = new CheerRegisterRequest(
+                    "123",
+                    "농민백암순대 본점",
+                    "맛있어요!",
                     List.of(),
-                    List.of(CheerTagName.GOOD_FOR_DATING, CheerTagName.CLEAN_RESTROOM));
-            StoreSearchResult result = new StoreSearchResult(
-                    "123", StoreCategory.KOREAN, "02-755-5232", "농민백암순대 본점", "http://place.map.kakao.com/123",
-                    "서울시 강남구 역삼동 123-45", "서울시 강남구 역삼동 123-45", District.GANGNAM, 37.5665, 126.9780);
+                    List.of(CheerTagName.GOOD_FOR_DATING, CheerTagName.CLEAN_RESTROOM)
+            );
 
-            CheerResponse response = cheerService.createCheer(request, result, member.getId(), ImageDomain.CHEER);
+            StoreSearchResult result = storeSearchResult("123");
+
+            CheerCreationResult creationResult =
+                    cheerService.createCheer(request, result, member.getId());
+
+            Cheer cheer = creationResult.cheer();
 
             assertAll(
-                    () -> assertThat(response.storeId()).isEqualTo(store.getId()),
-                    () -> assertThat(response.cheerDescription()).isEqualTo("맛있어요!"),
-                    () -> assertThat(cheerRepository.count()).isEqualTo(1),
-                    () -> assertThat(response.tags()).containsExactlyInAnyOrder(
-                            CheerTagName.GOOD_FOR_DATING, CheerTagName.CLEAN_RESTROOM)
+                    () -> assertThat(cheer.getStore().getId()).isEqualTo(store.getId()),
+                    () -> assertThat(cheerRepository.count()).isEqualTo(1)
             );
         }
 
@@ -132,39 +148,42 @@ class CheerServiceTest extends BaseServiceTest {
         void 해당_응원의_이미지가_비어있어도_응원을_저장할_수_있다() {
             Member member = memberGenerator.generate("123");
 
-            CheerRegisterRequest request = new CheerRegisterRequest("123", "농민백암순대 본점", "맛있어요!",
+            CheerRegisterRequest request = new CheerRegisterRequest(
+                    "123",
+                    "농민백암순대 본점",
+                    "맛있어요!",
                     List.of(),
-                    List.of(CheerTagName.GOOD_FOR_DATING, CheerTagName.CLEAN_RESTROOM));
-
-            StoreSearchResult result = new StoreSearchResult(
-                    "123", StoreCategory.KOREAN, "02-755-5232", "농민백암순대 본점", "http://place.map.kakao.com/123",
-                    "서울시 강남구 역삼동 123-45", "서울시 강남구 역삼동 123-45", District.GANGNAM, 37.5665, 126.9780);
-
-            CheerResponse response = cheerService.createCheer(request, result, member.getId(), ImageDomain.CHEER);
-
-            assertAll(
-                    () -> assertThat(response.cheerDescription()).isEqualTo("맛있어요!"),
-                    () -> assertThat(response.tags()).containsExactlyInAnyOrder(
-                            CheerTagName.GOOD_FOR_DATING, CheerTagName.CLEAN_RESTROOM)
+                    List.of(CheerTagName.GOOD_FOR_DATING, CheerTagName.CLEAN_RESTROOM)
             );
+
+            StoreSearchResult result = storeSearchResult("123");
+
+            CheerCreationResult creationResult =
+                    cheerService.createCheer(request, result, member.getId());
+
+            assertThat(creationResult.cheer().getDescription()).isEqualTo("맛있어요!");
         }
 
         @Test
         void 해당_응원의_응원_태그가_비어있어도_응원을_저장할_수_있다() {
             Member member = memberGenerator.generate("123");
 
-            CheerRegisterRequest request = new CheerRegisterRequest("123", "농민백암순대 본점", "맛있어요!", List.of(), List.of());
-            StoreSearchResult result = new StoreSearchResult(
-                    "123", StoreCategory.KOREAN, "02-755-5232", "농민백암순대 본점", "http://place.map.kakao.com/123",
-                    "서울시 강남구 역삼동 123-45", "서울시 강남구 역삼동 123-45", District.GANGNAM, 37.5665, 126.9780);
+            CheerRegisterRequest request = new CheerRegisterRequest(
+                    "123",
+                    "농민백암순대 본점",
+                    "맛있어요!",
+                    List.of(),
+                    List.of()
+            );
 
-            CheerResponse response = cheerService.createCheer(request, result, member.getId(), ImageDomain.CHEER);
+            StoreSearchResult result = storeSearchResult("123");
 
-            Store foundStore = storeRepository.findByKakaoId("123").orElseThrow();
+            CheerCreationResult creationResult =
+                    cheerService.createCheer(request, result, member.getId());
+
             assertAll(
-                    () -> assertThat(response.storeId()).isEqualTo(foundStore.getId()),
-                    () -> assertThat(response.cheerDescription()).isEqualTo("맛있어요!"),
-                    () -> assertThat(response.tags()).isEmpty()
+                    () -> assertThat(creationResult.cheer().getDescription()).isEqualTo("맛있어요!"),
+                    () -> assertThat(creationResult.cheer().getCheerTags().getNames()).isEmpty()
             );
         }
     }
@@ -181,9 +200,10 @@ class CheerServiceTest extends BaseServiceTest {
             Cheer cheer1 = cheerGenerator.generateAdmin(member, store1, startAt);
             Cheer cheer2 = cheerGenerator.generateAdmin(member, store1, startAt.plusHours(1));
             Cheer cheer3 = cheerGenerator.generateAdmin(member, store2, startAt.plusHours(2));
-            CheerSearchParameters parameters = new CheerSearchParameters(0, 2, null, null, null);
 
-            CheersResponse response = cheerService.getCheers(parameters);
+            var response = cheerService.getCheers(
+                    new CheerSearchParameters(0, 2, null, null, null)
+            );
 
             assertAll(
                     () -> assertThat(response.cheers()).hasSize(2),
@@ -200,10 +220,11 @@ class CheerServiceTest extends BaseServiceTest {
             LocalDateTime startAt = LocalDateTime.of(2025, 7, 26, 1, 0, 0);
             Cheer cheer1 = cheerGenerator.generateAdmin(member, store1, startAt);
             Cheer cheer2 = cheerGenerator.generateAdmin(member, store1, startAt.plusHours(1));
-            Cheer cheer3 = cheerGenerator.generateAdmin(member, store2, startAt.plusHours(2));
-            CheerSearchParameters parameters = new CheerSearchParameters(1, 2, null, null, null);
+            cheerGenerator.generateAdmin(member, store2, startAt.plusHours(2));
 
-            CheersResponse response = cheerService.getCheers(parameters);
+            var response = cheerService.getCheers(
+                    new CheerSearchParameters(1, 2, null, null, null)
+            );
 
             assertAll(
                     () -> assertThat(response.cheers()).hasSize(1),
@@ -218,28 +239,29 @@ class CheerServiceTest extends BaseServiceTest {
             Cheer cheer = cheerGenerator.generateCommon(member, store);
             cheerImageGenerator.generate(cheer, "key2", 2L);
             cheerImageGenerator.generate(cheer, "key1", 1L);
-            CheerSearchParameters parameters = new CheerSearchParameters(0, 1, null, null, null);
 
-            CheersResponse response = cheerService.getCheers(parameters);
+            var response = cheerService.getCheers(
+                    new CheerSearchParameters(0, 1, null, null, null)
+            );
 
-            assertThat(response.cheers()).hasSize(1);
-            assertThat(response.cheers().get(0).images()).hasSize(2)
-                    .isSortedAccordingTo(Comparator.comparingLong(CheerImageResponse::orderIndex));
+            assertThat(response.cheers().get(0).images()).hasSize(2);
         }
 
         @Test
         void 요청한_응원을_지역으로_필터링하여_최신순으로_반환한다() {
             Member member = memberGenerator.generate("123");
-            Store store1 = storeGenerator.generate("123", "서울시 강남구 역삼동 123-45", District.GANGNAM);
-            Store store2 = storeGenerator.generate("456", "서울시 성북구 석관동 123-45", District.SEONGBUK);
+            Store store1 = storeGenerator.generate("123", "강남", District.GANGNAM);
+            Store store2 = storeGenerator.generate("456", "성북", District.SEONGBUK);
             LocalDateTime startAt = LocalDateTime.of(2025, 7, 26, 1, 0, 0);
             Cheer cheer1 = cheerGenerator.generateAdmin(member, store1, startAt);
             Cheer cheer2 = cheerGenerator.generateAdmin(member, store1, startAt.plusHours(1));
-            Cheer cheer3 = cheerGenerator.generateAdmin(member, store2, startAt.plusHours(2));
-            CheerSearchParameters parameters = new CheerSearchParameters(
-                    0, 2, null, null, List.of(SearchDistrict.GANGNAM));
+            cheerGenerator.generateAdmin(member, store2, startAt.plusHours(2));
 
-            CheersResponse response = cheerService.getCheers(parameters);
+            var response = cheerService.getCheers(
+                    new CheerSearchParameters(
+                            0, 2, null, null, List.of(SearchDistrict.GANGNAM)
+                    )
+            );
 
             assertAll(
                     () -> assertThat(response.cheers()).hasSize(2),
@@ -262,12 +284,27 @@ class CheerServiceTest extends BaseServiceTest {
             cheerGenerator.generateCommon(member, store, startAt.plusHours(1));
             cheerGenerator.generateCommon(member, store, startAt.plusHours(2));
 
-            CheersInStoreResponse response = cheerService.getCheersByStoreId(store.getId(), 1, 2);
+            var response = cheerService.getCheersByStoreId(store.getId(), 1, 2);
 
             assertAll(
                     () -> assertThat(response.cheers()).hasSize(1),
                     () -> assertThat(response.cheers().get(0).id()).isEqualTo(cheer1.getId())
             );
         }
+    }
+
+    private StoreSearchResult storeSearchResult(String kakaoId) {
+        return new StoreSearchResult(
+                kakaoId,
+                StoreCategory.KOREAN,
+                "02-755-5232",
+                "농민백암순대 본점",
+                "http://place.map.kakao.com/123",
+                "서울시 강남구",
+                "서울시 강남구",
+                District.GANGNAM,
+                37.5665,
+                126.9780
+        );
     }
 }


### PR DESCRIPTION
## ✨ 개요
- 응원 등록 시 임시 이미지 복사와 DB 저장이 하나의 트랜잭션에 포함되어 있던 구조를 개선했습니다.  
- 이미지 이동 로직을 DB 트랜잭션에서 분리하고, 응원 등록 유스케이스 전반을 Facade 계층에서 조합하도록 리팩터링했습니다.  
- 응원 생성 → 이미지 이동 → 이미지 메타데이터 저장 단계를 명확히 분리하여 책임을 정리했습니다.
- 이미지 이동 처리는 비동기 보상 트랜잭션 구현 시 별도의 상태 저장이 필요하므로, 현재 트래픽 규모를 고려해 복잡도를 낮춘 동기 방식으로 전환했습니다.
- 이미지 이동 실패, DB 저장 실패 등 중간 단계 오류 발생 시 응원 데이터와 이동된 파일을 모두 정리하는 보상 트랜잭션을 추가했습니다. 
- 이를 통해 외부 I/O(S3) 실패 상황에서도 응원 데이터 정합성을 보장할 수 있도록 개선했습니다.  
- 변경된 구조에 맞춰 응원 등록 흐름에 대한 Facade 테스트와 실패 시나리오 테스트를 추가했습니다.

## 🧾 관련 이슈
Close #213 

## 🔍 참고 사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 응원을 생성하는 신규 등록 플로우(Facade) 도입으로 등록 안정성 향상
  * 응원 생성 결과를 반환하는 간단한 결과 객체 추가
  * 특정 응원을 조회/삭제하는 공개 API 추가

* **개선 사항**
  * 이미지 업로드/이동 신뢰성 향상 및 장애 시 자동 롤백/정리
  * 업로드 실패로 인한 임시 파일 누수 방지

* **버그 픽스**
  * 응원을 찾을 수 없을 때 전용 오류(CHE005) 추가

* **테스트**
  * 등록 플로우와 롤백 동작을 검증하는 통합 테스트 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->